### PR TITLE
🎨 Palette: Contact Form & Social Links Accessibility Polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-05-23 - Spinner Accessibility & Build Artifacts
 **Learning:** Decorative SVG icons (like loading spinners) inside interactive elements must include `aria-hidden="true"` to prevent redundant screen reader announcements. Also, `next-env.d.ts` is auto-generated and should be excluded from commits.
 **Action:** Always add `aria-hidden="true"` to decorative SVGs and check `git status` for auto-generated files before committing.
+
+## 2025-05-30 - Accessible Icon-Only Links and Form Validation
+**Learning:** Icon-only links using font icons (like Material Symbols) were being read aloud by their icon name (e.g., "code", "send") instead of their function, and form inputs relied solely on placeholders for labels, which is a common accessibility failure. Furthermore, visual form errors were not linked to the input for screen reader users.
+**Action:** When creating icon-only interactive elements, apply an `aria-label` to the parent and `aria-hidden="true"` to the font-icon `<span>`. For forms, always include a visually hidden label (`sr-only`), and when displaying error states, add `aria-invalid={true}` and `aria-describedby="error-id"` to the input, alongside `role="alert"` on the error text itself.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -245,14 +245,14 @@ const Contact = () => {
                                             Connect
                                         </h4>
                                         <div className="flex flex-wrap gap-3 sm:gap-4">
-                                            <a href={portfolioData.personal.social.github} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">code</span>
+                                            <a href={portfolioData.personal.social.github} target="_blank" rel="noopener noreferrer" aria-label="GitHub Profile" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">code</span>
                                             </a>
-                                            <a href={portfolioData.personal.social.linkedin} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">work</span>
+                                            <a href={portfolioData.personal.social.linkedin} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn Profile" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">work</span>
                                             </a>
-                                            <a href={`mailto:${portfolioData.personal.email}`} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">send</span>
+                                            <a href={`mailto:${portfolioData.personal.email}`} aria-label="Send an email" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">send</span>
                                             </a>
                                         </div>
                                     </div>
@@ -262,6 +262,7 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name</label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -275,6 +276,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email</label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -284,10 +286,13 @@ const Contact = () => {
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
                                                 required
+                                                aria-invalid={!!emailError}
+                                                aria-describedby={emailError ? "email-error" : undefined}
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono" role="alert">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message</label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
## 🎨 Palette: Contact Form & Social Links Accessibility Polish

💡 **What:** 
- Added visually hidden `<label>` elements for Name, Email, and Message inputs.
- Linked validation errors to inputs using `aria-invalid` and `aria-describedby`.
- Added descriptive `aria-label` attributes to the icon-only social links (GitHub, LinkedIn, Email).
- Added `aria-hidden="true"` to the material symbol spans to prevent screen readers from reading the icon text ("code", "send", etc.).
- Ensured external social links open safely in new tabs (`target="_blank" rel="noopener noreferrer"`).

🎯 **Why:** 
Inputs relying solely on placeholders provide a poor experience for screen reader users and users with cognitive disabilities. When validation fails, screen readers need to be programmatically informed that an input is invalid and be able to read the specific error. Icon-only buttons using text-based icon fonts confuse screen readers if not properly labeled and hidden. These targeted additions make the contact section significantly more robust and accessible.

♿ **Accessibility:**
- Resolved missing labels for form controls.
- Improved programmatic association of error messages.
- Fixed screen reader announcements for decorative icon fonts.

---
*PR created automatically by Jules for task [943393632340674118](https://jules.google.com/task/943393632340674118) started by @SudoAnirudh*