### PR TITLE
🛡️ Sentinel: [HIGH] Fix JSON-LD XSS and Reverse Tabnabbing

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** User inputs (name, email, message) were directly interpolated into HTML strings in the `contact.ts` server action before being sent via Resend. This allowed malicious users to submit HTML/script tags that would render in the recipient's email client.
 **Learning:** Even internal notification emails sent via APIs like Resend require HTML sanitization to prevent XSS and HTML injection, especially when user input is displayed back to the user or an administrator.
 **Prevention:** Always sanitize/escape user inputs before interpolating them into HTML templates, even for emails. Ensure escaping happens *before* applying text transformations like replacing newlines with `<br>`.
+
+## 2024-06-14 - [JSON-LD XSS & Reverse Tabnabbing]
+**Vulnerability:** Stringified JSON-LD was injected into a script tag using `dangerouslySetInnerHTML` without escaping, allowing XSS. Additionally, `target="_blank"` links in Hero component lacked `rel="noopener noreferrer"`, exposing a reverse tabnabbing vulnerability.
+**Learning:** `JSON.stringify` does not escape `<` characters, so a malicious input could prematurely close a `<script>` block and inject executable code. For tabnabbing, any new tab opened via target blank retains access to the window opener unless explicitly blocked.
+**Prevention:** Sanitize JSON strings before DOM injection using `.replace(/</g, '\\u003c')`. Always add `rel="noopener noreferrer"` to dynamically or statically generated `target="_blank"` anchor tags.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -103,7 +103,7 @@ export default function RootLayout({
         <div className="fixed inset-0 pointer-events-none opacity-[0.03] bg-[url('https://grainy-gradients.vercel.app/noise.svg')] z-50"></div>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
         />
         {/* Helper for cursor hiding handled inside component, but adding it here to be safe */}
         <RetroCursor />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -92,6 +92,7 @@ const Hero = () => {
                                             key={index}
                                             href={action.href}
                                             target={!action.primary ? "_blank" : undefined}
+                                            rel={!action.primary ? "noopener noreferrer" : undefined}
                                             onClick={(e) => handleActionClick(e, action)}
                                             className="flex items-center gap-2 group cursor-pointer"
                                         >


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: 
1. JSON-LD in layout.tsx allowed potential XSS through unescaped `<` characters breaking out of the script tag.
2. Reverse tabnabbing vulnerability in Hero.tsx on external action links.

🎯 Impact:
1. Malicious payloads containing literal script tags might execute unintended JS code.
2. Newly opened tabs could manipulate the original window location.

🔧 Fix:
1. Replaced `<` with unicode `\u003c` during JSON.stringify to safely render within script tags.
2. Followed conditional `target="_blank"` logic to append `rel="noopener noreferrer"` to external anchors.

✅ Verification: Verified syntax validity via standalone regex replacement test script. Linting and Vitest unavailable due to isolated environment without `node_modules`, logic holds statically.

---
*PR created automatically by Jules for task [11385242080459672372](https://jules.google.com/task/11385242080459672372) started by @SudoAnirudh*