### PR TITLE
🎨 Palette: Improve contact form accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2025-05-23 - Spinner Accessibility & Build Artifacts
 **Learning:** Decorative SVG icons (like loading spinners) inside interactive elements must include `aria-hidden="true"` to prevent redundant screen reader announcements. Also, `next-env.d.ts` is auto-generated and should be excluded from commits.
 **Action:** Always add `aria-hidden="true"` to decorative SVGs and check `git status` for auto-generated files before committing.
+
+## 2025-06-15 - Enhancing Contact Form Accessibility
+**Learning:** Contact form inputs lacked associated `htmlFor` labels, used `focus:outline-none` without `focus-visible` ring fallbacks, and the email error text was not programmatically linked via `aria-describedby` with an `aria-invalid` state.
+**Action:** Always add `<label>` with `htmlFor` matching the input `id`. Add `aria-invalid` to invalid inputs and connect error messages via `aria-describedby`. Replace `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent`.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -262,38 +262,43 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name <span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
                                                 name="name"
                                                 value={formData.name}
                                                 onChange={handleChange}
-                                                className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400"
+                                                className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus-visible:outline-none focus-visible:border-black focus-visible:ring-2 focus-visible:ring-accent transition-colors placeholder-zinc-400"
                                                 placeholder="ENTER NAME..."
                                                 type="text"
                                                 required
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email <span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
                                                 value={formData.email}
                                                 onChange={handleChange}
-                                                className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
+                                                className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus-visible:outline-none focus-visible:border-black focus-visible:ring-2 focus-visible:ring-accent transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
                                                 required
+                                                aria-invalid={!!emailError}
+                                                aria-describedby={emailError ? "email-error" : undefined}
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message <span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"
                                                 value={formData.message}
                                                 onChange={handleChange}
-                                                className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
+                                                className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus-visible:outline-none focus-visible:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] focus-visible:ring-2 focus-visible:ring-accent transition-shadow resize-none h-40 sm:h-48"
                                                 placeholder="TYPE YOUR MESSAGE HERE..."
                                                 required
                                             ></textarea>


### PR DESCRIPTION
🎨 Palette has reviewed the `Contact.tsx` component and identified several crucial accessibility gaps in the form inputs. 

To make the form usable for everyone:
1. **Semantic Labels**: Added `sr-only` labels to all inputs (`Name`, `Email`, `Message`), connected properly via `htmlFor` and `id`, ensuring screen readers can announce the purpose of each field.
2. **Keyboard Focus States**: The previous `focus:outline-none` implementation completely hid focus styling, which is extremely detrimental to keyboard users. This has been updated to use modern `focus-visible` utility classes (`focus-visible:ring-2 focus-visible:ring-accent`), which restores focus indicators for keyboard navigation while remaining hidden for mouse clicks.
3. **Error Association**: When an email validation error occurs, it is now programmatically tied to the input field using `aria-invalid` and `aria-describedby`, ensuring assistive technologies can announce the error state and read the specific error message to the user.

These changes are verified via code review to maintain the existing visual design while significantly upgrading the semantic meaning and usability of the contact form. A journal entry capturing this pattern has been logged to `.Jules/palette.md`.

---
*PR created automatically by Jules for task [3644929007439056207](https://jules.google.com/task/3644929007439056207) started by @SudoAnirudh*