### PR TITLE
🎨 Palette: Form inputs a11y enhancement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2025-05-23 - Spinner Accessibility & Build Artifacts
 **Learning:** Decorative SVG icons (like loading spinners) inside interactive elements must include `aria-hidden="true"` to prevent redundant screen reader announcements. Also, `next-env.d.ts` is auto-generated and should be excluded from commits.
 **Action:** Always add `aria-hidden="true"` to decorative SVGs and check `git status` for auto-generated files before committing.
+## 2026-06-18 - Contact Form Accessibility Improvements
+**Learning:** Relying solely on placeholders for form inputs is an accessibility anti-pattern because placeholders disappear when the user starts typing and are often not announced reliably by all screen readers. Error messages must also be programmatically linked to their inputs.
+**Action:** Always provide explicit `<label>` elements. For visually minimal designs, use `sr-only` classes to hide the label visually while keeping it available to assistive technologies. Use `aria-invalid` to indicate errors and `aria-describedby` to link the input to the specific element containing the error message.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -262,6 +262,7 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name</label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -275,6 +276,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email</label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -284,10 +286,13 @@ const Contact = () => {
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
                                                 required
+                                                aria-invalid={emailError ? 'true' : 'false'}
+                                                aria-describedby={emailError ? 'email-error' : undefined}
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message</label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
💡 What: Added screen-reader-only `<label>` elements for all inputs in the Contact form. Linked the dynamic email error message to the email input using `aria-invalid` and `aria-describedby`.
🎯 Why: Form inputs were previously relying entirely on placeholders, which causes issues for screen reader users and those with cognitive disabilities when placeholders disappear. Screen readers also need to know when an input is invalid and what the error message is.
📸 Before/After: Visual changes are nil (retained the existing aesthetic). Only DOM changes.
♿ Accessibility: Improved form accessibility by explicitly providing semantic labels and ARIA error connections.

---
*PR created automatically by Jules for task [17023011007848507532](https://jules.google.com/task/17023011007848507532) started by @SudoAnirudh*