### PR TITLE
🎨 Palette: Add ARIA labels and fix accessibility in Retro Music Player

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-30 - [Material Symbols ARIA Hidden]
+**Learning:** The application uses Google Material Symbols which rely on text ligatures (e.g., skip_previous). Screen readers will read the raw text of these icons out loud if not hidden.
+**Action:** Always add aria-hidden="true" to the span elements containing these icons and provide aria-label on the parent button.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -124,11 +124,14 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
+                        aria-label="Minimize Player"
+                        title="Minimize Player"
                     >_</button>
                     <button 
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
+                        aria-label="Close Player"
                     >X</button>
                 </div>
                 {/* Horizontal Scanlines Overlay on bar */}
@@ -159,21 +162,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900" aria-label="Previous Track" title="Previous Track">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900" aria-label={isPlaying ? "Pause" : "Play"} title={isPlaying ? "Pause" : "Play"}>
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900" aria-label="Next Track" title="Next Track">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 What: Added necessary ARIA labels and structural associations to the `RetroMusicPlayer` component to improve accessibility.
🎯 Why: The component contained several icon-only buttons (minimize, close, audio controls) that lacked labels, making them inaccessible to screen readers. Additionally, Google Material Symbols text ligatures were not hidden, causing screen readers to read out raw text like "skip_previous". Finally, the volume slider lacked an associated label.
📸 Before/After: No visual changes.
♿ Accessibility:
- Added `aria-label` to minimize, close, previous track, play/pause, and next track buttons.
- Added `aria-hidden="true"` to `span` elements containing Google Material Symbols text ligatures.
- Associated the Volume `<label>` with its `<input type="range">` using `htmlFor` and `id`.

---
*PR created automatically by Jules for task [7042975347702743016](https://jules.google.com/task/7042975347702743016) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility Improvements**
  * Enhanced music player controls with descriptive labels for screen reader users, ensuring all playback buttons and the volume slider are properly identified and accessible through assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->