### PR TITLE
🛡️ Sentinel: Add security headers to Next.js configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-02 - Add Security Headers to Next.js
+**Vulnerability:** Missing standard security headers (HSTS, X-Frame-Options, X-Content-Type-Options, etc.), exposing the application to common web vulnerabilities like clickjacking, MIME-sniffing, and XSS.
+**Learning:** Next.js allows easy configuration of security headers via the `headers()` async function in `next.config.ts`.
+**Prevention:** Always configure security headers in `next.config.ts` for Next.js applications to provide defense in depth.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,35 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname),
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "X-XSS-Protection",
+            value: "1; mode=block",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Add standard security headers to `next.config.ts` to provide defense in depth against common web vulnerabilities.

This includes:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `X-XSS-Protection: 1; mode=block`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Strict-Transport-Security: max-age=31536000; includeSubDomains`

---
*PR created automatically by Jules for task [7018470925547744289](https://jules.google.com/task/7018470925547744289) started by @SudoAnirudh*