### PR TITLE
🛡️ Sentinel: [security improvement] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-20 - Ensure Global Security Headers Configuration in Next.js
+**Vulnerability:** The Next.js application was missing standard HTTP security headers (e.g., `X-Frame-Options`, `X-Content-Type-Options`, `Strict-Transport-Security`, `X-XSS-Protection`, `Referrer-Policy`), leaving the application exposed to clickjacking, MIME-sniffing, and other web vulnerabilities.
+**Learning:** In Next.js, standard security headers should be explicitly configured globally in `next.config.ts` using the `async headers()` function to provide defense in depth across all routes.
+**Prevention:** Always verify that `next.config.ts` includes an implementation of `async headers()` returning standard HTTP security headers applying to `/(.*)`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,35 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: path.resolve(__dirname),
   },
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+          {
+            key: "X-Frame-Options",
+            value: "DENY",
+          },
+          {
+            key: "X-XSS-Protection",
+            value: "1; mode=block",
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000; includeSubDomains; preload",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers.
🎯 Impact: The application could be more easily susceptible to clickjacking, MIME-sniffing attacks, and other web vulnerabilities because defensive headers like `X-Frame-Options` and `X-Content-Type-Options` are not set.
🔧 Fix: Added an `async headers()` configuration to `next.config.ts` applying the `nosniff`, `DENY` (frame options), `1; mode=block` (XSS protection), `strict-origin-when-cross-origin` (Referrer-Policy), and `max-age=31536000; includeSubDomains; preload` (HSTS) headers to all routes `/(.*)`.
✅ Verification: Ran `pnpm build` successfully, then verified by running `pnpm start` and observing the headers using `curl` or `http.get` on `localhost:3000`.

---
*PR created automatically by Jules for task [9673863563931272120](https://jules.google.com/task/9673863563931272120) started by @SudoAnirudh*