### PR TITLE
🎨 Palette: Add explicit labels and error association to contact form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-20 - [Forms Accessibility] Form Fields Need Proper Labels and Error Association
+**Learning:** Relying solely on placeholders for form fields is insufficient for accessibility, as placeholders disappear on input and aren't always read correctly by screen readers. Furthermore, dynamically rendered error messages must be explicitly associated with their corresponding input fields using `aria-describedby` so that assistive technologies announce the error context.
+**Action:** Always provide explicit `<label>` elements (even if visually hidden via `.sr-only`) for all form fields. Use `aria-invalid` and `aria-describedby` on inputs to programmatically link them to their respective error message containers.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -262,6 +262,7 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name</label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -275,6 +276,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email</label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -284,10 +286,13 @@ const Contact = () => {
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
                                                 required
+                                                aria-invalid={emailError ? "true" : "false"}
+                                                aria-describedby={emailError ? "email-error" : undefined}
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message</label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
💡 What: Added visually hidden `<label>` elements to the Name, Email, and Message fields in the Contact form. Also, properly connected the email input field to its dynamically rendered error message using `aria-invalid` and `aria-describedby`.
🎯 Why: Relying solely on `placeholder` attributes for context is insufficient for accessibility, as placeholders disappear and are not consistently announced by screen readers. Furthermore, without `aria-describedby`, screen readers may not announce validation errors to users when they occur.
📸 Before/After: Visuals remain entirely unchanged, as all new text labels are rendered with `.sr-only`. 
♿ Accessibility: Ensures that screen reader users can reliably identify each form field and have validation errors read aloud in context.

---
*PR created automatically by Jules for task [14187034439928803744](https://jules.google.com/task/14187034439928803744) started by @SudoAnirudh*