### PR TITLE
🎨 Palette: Improve Contact Form & Social Links Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2025-05-23 - Spinner Accessibility & Build Artifacts
 **Learning:** Decorative SVG icons (like loading spinners) inside interactive elements must include `aria-hidden="true"` to prevent redundant screen reader announcements. Also, `next-env.d.ts` is auto-generated and should be excluded from commits.
 **Action:** Always add `aria-hidden="true"` to decorative SVGs and check `git status` for auto-generated files before committing.
+## 2025-05-16 - Social Links Accessibility Pattern
+**Learning:** Icon-only social links using `material-symbols-outlined` need screen-reader accessible labels, `aria-hidden="true"` on the icon itself to prevent the literal icon name from being read, and correct keyboard focus states using `focus-visible`. External links should also use `target="_blank"` alongside `rel="noopener noreferrer"`.
+**Action:** Always add `aria-label` to icon-only links. Add `aria-hidden="true"` to inner decorative elements. Use `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent` for focus states. Pair `target="_blank"` with `rel="noopener noreferrer"`.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -245,14 +245,14 @@ const Contact = () => {
                                             Connect
                                         </h4>
                                         <div className="flex flex-wrap gap-3 sm:gap-4">
-                                            <a href={portfolioData.personal.social.github} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">code</span>
+                                            <a aria-label="GitHub Profile" target="_blank" rel="noopener noreferrer" href={portfolioData.personal.social.github} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+                                                <span className="material-symbols-outlined" aria-hidden="true">code</span>
                                             </a>
-                                            <a href={portfolioData.personal.social.linkedin} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">work</span>
+                                            <a aria-label="LinkedIn Profile" target="_blank" rel="noopener noreferrer" href={portfolioData.personal.social.linkedin} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+                                                <span className="material-symbols-outlined" aria-hidden="true">work</span>
                                             </a>
-                                            <a href={`mailto:${portfolioData.personal.email}`} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">send</span>
+                                            <a aria-label="Send Email" target="_blank" rel="noopener noreferrer" href={`mailto:${portfolioData.personal.email}`} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent">
+                                                <span className="material-symbols-outlined" aria-hidden="true">send</span>
                                             </a>
                                         </div>
                                     </div>
@@ -262,38 +262,43 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name</label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
                                                 name="name"
                                                 value={formData.name}
                                                 onChange={handleChange}
-                                                className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400"
+                                                className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus:border-black transition-colors placeholder-zinc-400"
                                                 placeholder="ENTER NAME..."
                                                 type="text"
                                                 required
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email</label>
                                             <input
                                                 id="email"
                                                 name="email"
                                                 value={formData.email}
                                                 onChange={handleChange}
-                                                className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
+                                                className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
+                                                aria-invalid={!!emailError}
+                                                aria-describedby={emailError ? "email-error" : undefined}
                                                 required
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message</label>
                                             <textarea
                                                 id="message"
                                                 name="message"
                                                 value={formData.message}
                                                 onChange={handleChange}
-                                                className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
+                                                className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
                                                 placeholder="TYPE YOUR MESSAGE HERE..."
                                                 required
                                             ></textarea>


### PR DESCRIPTION
💡 What: Added screen-reader-only labels to the contact form inputs, associated error messages correctly, added `aria-label` and `aria-hidden` to icon-only social links, and updated focus styles to use `focus-visible`.
🎯 Why: To improve the accessibility of the contact section for screen-reader and keyboard users, ensuring all inputs have accessible names and interactive elements have clear focus states.
📸 Before/After: Visuals remain unchanged for standard users, but screen reader and keyboard accessibility is vastly improved.
♿ Accessibility:
  - Added `<label className="sr-only">` to Name, Email, and Message fields.
  - Linked email error message using `aria-invalid` and `aria-describedby`.
  - Added `aria-label` to GitHub, LinkedIn, and Email anchor tags.
  - Added `aria-hidden="true"` to `material-symbols-outlined` spans within icon links.
  - Replaced `focus:outline-none` with `focus-visible:ring-2` patterns for all inputs and links to support keyboard navigation.
  - Added `target="_blank" rel="noopener noreferrer"` for external social links.

---
*PR created automatically by Jules for task [13732595965641745355](https://jules.google.com/task/13732595965641745355) started by @SudoAnirudh*