### PR TITLE
🎨 Palette: Form & Social Links Accessibility Improvement

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2025-05-23 - Spinner Accessibility & Build Artifacts
 **Learning:** Decorative SVG icons (like loading spinners) inside interactive elements must include `aria-hidden="true"` to prevent redundant screen reader announcements. Also, `next-env.d.ts` is auto-generated and should be excluded from commits.
 **Action:** Always add `aria-hidden="true"` to decorative SVGs and check `git status` for auto-generated files before committing.
+## 2024-05-18 - Form and Social Links Accessibility Improvements
+**Learning:** In the `Contact.tsx` component, form inputs were relying solely on placeholders without `<label>` elements, which breaks screen reader support. Social icons were missing `aria-label`s, and text inside `span` with `material-symbols-outlined` was being read by screen readers.
+**Action:** Always provide `<label>` elements (using `sr-only` class if they should be visually hidden) for inputs, associate error states using `aria-invalid` and `aria-describedby`, add `aria-label` to icon-only links, and use `aria-hidden="true"` on the internal icon elements to prevent redundant reading. Also ensure external links include `target="_blank" rel="noopener noreferrer"` for security.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -245,14 +245,14 @@ const Contact = () => {
                                             Connect
                                         </h4>
                                         <div className="flex flex-wrap gap-3 sm:gap-4">
-                                            <a href={portfolioData.personal.social.github} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">code</span>
+                                            <a href={portfolioData.personal.social.github} aria-label="GitHub Profile" target="_blank" rel="noopener noreferrer" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-black hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">code</span>
                                             </a>
-                                            <a href={portfolioData.personal.social.linkedin} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">work</span>
+                                            <a href={portfolioData.personal.social.linkedin} aria-label="LinkedIn Profile" target="_blank" rel="noopener noreferrer" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-blue-700 hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">work</span>
                                             </a>
-                                            <a href={`mailto:${portfolioData.personal.email}`} className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors">
-                                                <span className="material-symbols-outlined">send</span>
+                                            <a href={`mailto:${portfolioData.personal.email}`} aria-label="Send an Email" className="w-12 h-12 border-2 border-black flex items-center justify-center hover:bg-red-500 hover:text-white transition-colors">
+                                                <span className="material-symbols-outlined" aria-hidden="true">send</span>
                                             </a>
                                         </div>
                                     </div>
@@ -262,6 +262,7 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            <label htmlFor="name" className="sr-only">Name</label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -275,6 +276,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
+                                            <label htmlFor="email" className="sr-only">Email</label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -283,11 +285,14 @@ const Contact = () => {
                                                 className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
+                                                aria-invalid={!!emailError}
+                                                aria-describedby={emailError ? "email-error" : undefined}
                                                 required
                                             />
-                                            {emailError && <p className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
+                                            {emailError && <p id="email-error" className="text-red-500 text-xs mt-1 font-bold font-mono">{emailError}</p>}
                                         </div>
                                         <div>
+                                            <label htmlFor="message" className="sr-only">Message</label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
**💡 What**
Added visually hidden `<label>` elements for the form inputs (Name, Email, Message) in `Contact.tsx`. Enhanced the Email input with `aria-invalid` and `aria-describedby` when an error occurs. For the social media links, added `aria-label` attributes for context, applied `aria-hidden="true"` to the decorative icon text elements, and included `target="_blank" rel="noopener noreferrer"` on external links.

**🎯 Why**
Form inputs relying solely on placeholders without proper `<label>` elements are inaccessible to screen readers, making it difficult for some users to navigate the contact form. Additionally, the icon-only social links lacked context, and screen readers were reading out the internal text ("code", "work", "send") which is confusing without labels. External links should always open securely. 

**📸 Before/After**
Before: Inputs had no `<label>`, social icons lacked `aria-label`, and screen readers read icon names.
After: Inputs have `<label className="sr-only">`, social links have context via `aria-label` and `aria-hidden` icons.

**♿ Accessibility**
- Added `sr-only` labels for all contact form text inputs and textareas.
- Programmatically linked the email input error state using `aria-invalid` and `aria-describedby`.
- Added descriptive `aria-label` attributes to the GitHub, LinkedIn, and Email icon-only links.
- Hid the text-based icon content from screen readers using `aria-hidden="true"`.

---
*PR created automatically by Jules for task [1426034754505616448](https://jules.google.com/task/1426034754505616448) started by @SudoAnirudh*