### PR TITLE
🎨 Palette: Add ARIA labels to RetroMusicPlayer controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-23 - RetroMusicPlayer accessibility improvements
+**Learning:** The RetroMusicPlayer component lacked ARIA labels on icon-only playback and window control buttons, and the volume slider label was disconnected from the input element.
+**Action:** Added aria-label, title, and aria-hidden attributes to icon buttons, and linked the volume label to its input using htmlFor and id to improve screen reader accessibility.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -124,10 +124,13 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
+                        aria-label={isMinimized ? "Maximize Player" : "Minimize Player"}
+                        title={isMinimized ? "Maximize Player" : "Minimize Player"}
                     >_</button>
                     <button 
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
+                        aria-label="Close Player"
                         title="Close Player"
                     >X</button>
                 </div>
@@ -159,21 +162,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button aria-label="Previous Track" title="Previous Track" onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-lg">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button aria-label={isPlaying ? "Pause" : "Play"} title={isPlaying ? "Pause" : "Play"} onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button aria-label="Next Track" title="Next Track" onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-lg">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 What: Added appropriate `aria-label`, `title`, and `aria-hidden` attributes to icon-only buttons in the RetroMusicPlayer (minimize, close, playback controls), and linked the volume label to its input element using `htmlFor` and `id`.

🎯 Why: To improve screen reader accessibility. Previously, the buttons only contained decorative text or icons which would not be clearly described to assistive technologies, and the volume slider lacked a programmatically associated label.

📸 Before/After: Visuals remain unchanged, but the DOM structure is now semantically correct.

♿ Accessibility:
- Added `aria-label` and `title` to the Minimize and Close buttons.
- Added `aria-label` and `title` to Previous Track, Play/Pause, and Next Track buttons.
- Added `aria-hidden="true"` to decorative `material-symbols-outlined` spans within buttons.
- Added `htmlFor` on the Volume label and an `id` on the range input to properly associate them.

---
*PR created automatically by Jules for task [17405712280833515053](https://jules.google.com/task/17405712280833515053) started by @SudoAnirudh*