### PR TITLE
🎨 Palette: Add ARIA labels and focus rings to RetroMusicPlayer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-11-20 - [ARIA Hidden on Text-Based Icons]
+**Learning:** When adding `aria-label` to icon-only buttons that contain text-based icon fonts (like `material-symbols-outlined`), screen readers may redundantly read the raw text of the icon (e.g., "skip_previous") if it is not hidden.
+**Action:** Always apply `aria-hidden="true"` to the inner `<span>` element containing the icon text to ensure the screen reader only reads the intended `aria-label` on the parent button.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -123,12 +123,14 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                 <div className="relative z-10 flex gap-1 no-drag">
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
-                        className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
+                        className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green"
+                        aria-label={isMinimized ? "Restore player" : "Minimize player"}
                     >_</button>
                     <button 
                         onClick={onClose}
-                        className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
+                        className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green"
                         title="Close Player"
+                        aria-label="Close player"
                     >X</button>
                 </div>
                 {/* Horizontal Scanlines Overlay on bar */}
@@ -159,28 +161,29 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button onClick={prevTrack} aria-label="Previous track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button onClick={togglePlay} aria-label={isPlaying ? "Pause" : "Play"} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green">
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button onClick={nextTrack} aria-label="Next track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"
                                 step="0.05"
                                 value={volume}
                                 onChange={(e) => setVolume(parseFloat(e.target.value))}
-                                className="w-full h-2 bg-zinc-700 appearance-none rounded-none accent-retro-green cursor-pointer"
+                                className="w-full h-2 bg-zinc-700 appearance-none rounded-none accent-retro-green cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-green"
                             />
                         </div>
                     </div>


### PR DESCRIPTION
**💡 What**
Added ARIA labels, associated the volume label with its input, explicitly hid text-based material symbols from screen readers using `aria-hidden="true"`, and improved keyboard navigation by adding a retro-green focus ring to the interactive buttons.

**🎯 Why**
The retro music player's control buttons relied exclusively on icon symbols and lacked text equivalents, meaning screen reader users would hear the raw text strings (e.g., "play_arrow", "remove") instead of meaningful descriptions. Furthermore, keyboard-only users had minimal visible indication of which control was currently focused.

**📸 Before/After**
*Before:*
`<button><span className="material-symbols-outlined">play_arrow</span></button>`

*After:*
`<button aria-label="Play" className="focus-visible:ring-2 focus-visible:ring-retro-green focus-visible:outline-none"><span className="material-symbols-outlined" aria-hidden="true">play_arrow</span></button>`

**♿ Accessibility**
- Added explicit `aria-label` to all icon-only control buttons.
- Applied `aria-hidden="true"` to icon spans to prevent screen readers from reading out string identifiers.
- Added `focus-visible` styling (`ring-2 ring-retro-green outline-none`) to support keyboard tabbing navigation.
- Linked "VOLUME" `<label>` text to its associated `<input type="range">` using the `htmlFor`/`id` pairing pattern.

---
*PR created automatically by Jules for task [13183324592281411083](https://jules.google.com/task/13183324592281411083) started by @SudoAnirudh*