### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing in Receipt Printer

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing standard security HTTP headers (e.g., X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy) which leaves the application susceptible to basic attacks like MIME-sniffing, clickjacking, and cross-site scripting (XSS).
 **Learning:** In Next.js, standard security headers should be configured globally by returning them from the `async headers()` function in `next.config.ts` to provide defense in depth.
 **Prevention:** Always implement an `async headers()` function in `next.config.ts` returning standard security headers applied to `/(.*)` at the start of any Next.js project.
+## 2024-05-24 - Window.Open Reverse Tabnabbing
+**Vulnerability:** Calling `window.open(url, "_blank")` without specifying `noopener,noreferrer` allows the newly opened tab to retain a reference to `window.opener`, posing a reverse tabnabbing risk on older browsers.
+**Learning:** Even if anchor tags use `rel="noopener noreferrer"`, programmatic window opens also need protection.
+**Prevention:** Always include `"noopener,noreferrer"` as the third argument when using `window.open` with `"_blank"`.

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -156,11 +156,11 @@ const AsciiCube = () => {
             const sinB = Math.sin(B);
             
             const projected = vertices.map(([x, y, z]) => {
-                let y1 = y * cosA - z * sinA;
-                let z1 = y * sinA + z * cosA;
+                const y1 = y * cosA - z * sinA;
+                const z1 = y * sinA + z * cosA;
                 
-                let x2 = x * cosB + z1 * sinB;
-                let z2 = -x * sinB + z1 * cosB;
+                const x2 = x * cosB + z1 * sinB;
+                const z2 = -x * sinB + z1 * cosB;
                 
                 const distance = 3.5;
                 const ooz = 1 / (distance - z2);

--- a/src/components/ReceiptPrinter.tsx
+++ b/src/components/ReceiptPrinter.tsx
@@ -139,7 +139,7 @@ const ReceiptPrinter: React.FC<ReceiptPrinterProps> = ({ onClose }) => {
     }, []);
 
     const handleDownload = () => {
-        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank");
+        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank", "noopener,noreferrer");
     };
 
     const handleDiscard = () => {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Calling `window.open(url, "_blank")` without specifying `noopener,noreferrer` allows the newly opened tab to retain a reference to `window.opener`, posing a reverse tabnabbing risk (particularly on older browsers). While external `<a>` tags in the project are protected, this programmatic call was not.
🎯 Impact: A malicious site opened via this link could manipulate the `window.opener` object, redirecting the original portfolio page to a phishing site or stealing data.
🔧 Fix: Added `"noopener,noreferrer"` as the third argument to the `window.open` call in `src/components/ReceiptPrinter.tsx`.
✅ Verification: Ensure the application builds successfully via `pnpm build`. Click the "Take It" button on the receipt printer and inspect the opened window to verify it does not have a reference back to the original page.

---
*PR created automatically by Jules for task [9433616231109313331](https://jules.google.com/task/9433616231109313331) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when opening receipt links in a new tab by adding protections against tabnabbing and referrer leakage.
* **Documentation**
  * Added a new note explaining the risks of opening links with `window.open` and the recommended safe settings.
* **Refactor**
  * Cleaned up some internal coordinate calculations without changing the displayed result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->