### PR TITLE
🎨 Palette: Add ARIA labels and associate form elements in RetroMusicPlayer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-08 - Accessible Retro Media Controls
+**Learning:** Custom retro UI components (like media players) often rely heavily on icon-only buttons (`_`, `X`, material symbols) and custom layout structures for volume sliders that lack semantic grouping, causing significant accessibility barriers for screen readers.
+**Action:** Always verify that interactive controls in simulated retro interfaces have descriptive `aria-label` attributes (and `aria-hidden="true"` on decorative inner text/icons) and that internal custom form elements are explicitly associated using `id` and `htmlFor`.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -122,10 +122,12 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                 </div>
                 <div className="relative z-10 flex gap-1 no-drag">
                     <button
+                        aria-label="Minimize Player"
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
                     >_</button>
                     <button 
+                        aria-label="Close Player"
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
@@ -159,21 +161,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button aria-label="Previous Track" onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-lg">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button aria-label={isPlaying ? "Pause" : "Play"} onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button aria-label="Next Track" onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span aria-hidden="true" className="material-symbols-outlined text-lg">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only buttons (minimize, close, and playback controls) in the `RetroMusicPlayer` component, added `aria-hidden="true"` to their inner spans, and explicitly associated the volume `<label>` with its `<input>` using `htmlFor` and `id`. Also documented the accessibility learning in `.jules/palette.md`.
🎯 Why: Without ARIA labels, screen reader users encounter contextless buttons (e.g., reading out "skip_previous" or just generic button roles), and disjointed form elements, making the media player difficult to use.
📸 Before/After: Visuals remain unchanged; DOM output includes correct accessibility attributes.
♿ Accessibility: Improves screen reader compatibility for interactive retro media components by providing semantic context to icon-only controls.

---
*PR created automatically by Jules for task [1312769642857153970](https://jules.google.com/task/1312769642857153970) started by @SudoAnirudh*