### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing in ReceiptPrinter

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing standard security HTTP headers (e.g., X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy) which leaves the application susceptible to basic attacks like MIME-sniffing, clickjacking, and cross-site scripting (XSS).
 **Learning:** In Next.js, standard security headers should be configured globally by returning them from the `async headers()` function in `next.config.ts` to provide defense in depth.
 **Prevention:** Always implement an `async headers()` function in `next.config.ts` returning standard security headers applied to `/(.*)` at the start of any Next.js project.
+## 2025-02-24 - [Mitigate Reverse Tabnabbing in Receipt Printer]
+**Vulnerability:** Reverse tabnabbing via `window.open` missing `noopener,noreferrer` parameters.
+**Learning:** Even programmatic link openings (via `window.open` rather than `<a target="_blank">`) can be vulnerable to `window.opener` abuse if the third argument is omitted.
+**Prevention:** Always append `"noopener,noreferrer"` as the third string argument when using `window.open(url, "_blank")`.

--- a/src/components/ReceiptPrinter.tsx
+++ b/src/components/ReceiptPrinter.tsx
@@ -139,7 +139,8 @@ const ReceiptPrinter: React.FC<ReceiptPrinterProps> = ({ onClose }) => {
     }, []);
 
     const handleDownload = () => {
-        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank");
+        // SECURITY: Prevents reverse tabnabbing by ensuring the new tab cannot access window.opener
+        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank", "noopener,noreferrer");
     };
 
     const handleDiscard = () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Reverse tabnabbing vulnerability where a newly opened tab (via `window.open`) can maliciously access and manipulate the originating window via `window.opener`.
🎯 Impact: An attacker controlling the destination URL of the new tab could execute phishing attacks or redirect the user's original tab to a malicious site.
🔧 Fix: Explicitly added the third string argument `"noopener,noreferrer"` to the `window.open` call in `src/components/ReceiptPrinter.tsx`. This explicitly isolates the new tab from the originating window's context.
✅ Verification: Tested the application build locally with `npm run build`. Verified that clicking "Take It" in the receipt printer component opens the external link correctly and securely.

---
*PR created automatically by Jules for task [12913585933609841152](https://jules.google.com/task/12913585933609841152) started by @SudoAnirudh*