### PR TITLE
🎨 Palette: Improve accessibility of RetroMusicPlayer component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-27 - Text-based Icon Font Accessibility in Custom Retro UI
+**Learning:** When using text-based icon fonts like `material-symbols-outlined` within icon-only interactive controls (e.g., custom window controls or media players), screen readers may attempt to read the literal text (e.g., 'skip_previous') if it isn't explicitly hidden, confusing users.
+**Action:** Always add `aria-hidden="true"` to the internal icon span element and provide a clear, descriptive `aria-label` on the parent `<button>` or `<a>` tag to ensure screen readers announce the intended action rather than the icon's ligature text.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -123,10 +123,12 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                 <div className="relative z-10 flex gap-1 no-drag">
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
+                        aria-label={isMinimized ? "Restore player" : "Minimize player"}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
                     >_</button>
                     <button 
                         onClick={onClose}
+                        aria-label="Close player"
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
                     >X</button>
@@ -159,21 +161,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button onClick={prevTrack} aria-label="Previous track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button onClick={togglePlay} aria-label={isPlaying ? "Pause" : "Play"} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button onClick={nextTrack} aria-label="Next track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
🎨 Palette: Improve accessibility of RetroMusicPlayer component

💡 What: Added comprehensive ARIA labels to icon-only buttons, hid text-based material icons from screen readers (`aria-hidden="true"`), and properly associated the volume slider with its label (`id` / `htmlFor`).
🎯 Why: Screen reader users previously heard "skip_previous button" or generic "button" when navigating the music player, and could not easily identify or focus the volume slider. This improves the overall keyboard/screen-reader experience.
📸 Before/After: Visuals remain unchanged (verified via UI snapshots).
♿ Accessibility: Improves compliance by providing clear textual alternatives for iconography and ensuring form inputs have semantically associated labels.

Fixes missing ARIA issues in `RetroMusicPlayer.tsx`.

---
*PR created automatically by Jules for task [4669004227477617360](https://jules.google.com/task/4669004227477617360) started by @SudoAnirudh*