### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing standard security HTTP headers (e.g., X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy) which leaves the application susceptible to basic attacks like MIME-sniffing, clickjacking, and cross-site scripting (XSS).
 **Learning:** In Next.js, standard security headers should be configured globally by returning them from the `async headers()` function in `next.config.ts` to provide defense in depth.
 **Prevention:** Always implement an `async headers()` function in `next.config.ts` returning standard security headers applied to `/(.*)` at the start of any Next.js project.
+
+## 2024-06-25 - Reverse Tabnabbing Vulnerability via window.open
+**Vulnerability:** A `window.open(url, "_blank")` call missing the third `features` argument with `"noopener,noreferrer"`. This exposes the application to reverse tabnabbing, where the newly opened window gains a reference to the `window.opener` object, potentially allowing a malicious site to navigate the original tab to a phishing or otherwise malicious page.
+**Learning:** Even programmatic navigation (using JavaScript's `window.open` rather than standard HTML anchor tags) that opens a new tab must be explicitly secured against cross-window manipulation to ensure defense in depth.
+**Prevention:** Always provide `"noopener,noreferrer"` as the third parameter to `window.open(url, '_blank')` to break the connection between the originating and new windows, just as `rel="noopener noreferrer"` does for HTML `<a>` tags.

--- a/src/components/ReceiptPrinter.tsx
+++ b/src/components/ReceiptPrinter.tsx
@@ -139,7 +139,7 @@ const ReceiptPrinter: React.FC<ReceiptPrinterProps> = ({ onClose }) => {
     }, []);
 
     const handleDownload = () => {
-        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank");
+        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank", "noopener,noreferrer");
     };
 
     const handleDiscard = () => {


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: A `window.open(url, "_blank")` call was missing the third `features` argument with `"noopener,noreferrer"`. This exposes the application to reverse tabnabbing, where the newly opened window gains a reference to the `window.opener` object, potentially allowing a malicious site to navigate the original tab to a phishing or otherwise malicious page.
🎯 **Impact**: If a user clicks the button and the target page is compromised, the original tab could be navigated to a malicious site.
🔧 **Fix**: Added `"noopener,noreferrer"` as the third parameter to `window.open` in `src/components/ReceiptPrinter.tsx` to explicitly secure against cross-window manipulation.
✅ **Verification**: Run `pnpm lint` and `pnpm build` to verify no regressions were introduced. Check `src/components/ReceiptPrinter.tsx` to verify the fix.

---
*PR created automatically by Jules for task [6856402182563855168](https://jules.google.com/task/6856402182563855168) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when opening download links in a new tab or window by preventing access back to the original page.
* **Documentation**
  * Added guidance on safe link-opening behavior to help avoid reverse tabnabbing risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->