### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to RetroMusicPlayer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-27 - [Add ARIA labels to RetroMusicPlayer]
+**Learning:** Found a pattern in retro UI components (`RetroMusicPlayer.tsx`) where icon-only buttons (minimize, close, playback controls) lacked `aria-label`s. In addition, internal form elements like the volume slider lacked explicitly associated labels.
+**Action:** Always verify that icon-only interactive controls (minimize, close, playback) have descriptive `aria-label` attributes, and internal custom form elements are correctly associated with labels using `id` and `htmlFor`. Hide decorative or textual icons with `aria-hidden="true"`.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -122,10 +122,12 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                 </div>
                 <div className="relative z-10 flex gap-1 no-drag">
                     <button
+                        aria-label="Minimize Player"
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
                     >_</button>
                     <button 
+                        aria-label="Close Player"
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
@@ -159,21 +161,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button aria-label="Previous Track" onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button aria-label={isPlaying ? "Pause Track" : "Play Track"} onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button aria-label="Next Track" onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 What: Added `aria-label`s to the icon-only buttons in the `RetroMusicPlayer` and linked the volume slider to its label. Added `aria-hidden="true"` to inner icon elements.
🎯 Why: Without these attributes, screen readers read the raw text of the material symbols (e.g., "skip_next") or announce generic "button" elements without context, making the music player difficult or impossible to use for visually impaired users. Additionally, the volume slider was an isolated input without a programmatic label association.
📸 Before/After: Visual presentation is strictly identical, but semantic accessibility has vastly improved.
♿ Accessibility: Ensures that screen reader users can understand and interact with the minimize, close, playback controls, and volume adjustments.

Added an entry to `.jules/palette.md` noting the pattern of custom retro OS/Win95 style components often missing standard form/button accessibility labels.

---
*PR created automatically by Jules for task [1041233454150993710](https://jules.google.com/task/1041233454150993710) started by @SudoAnirudh*