### PR TITLE
🛡️ Sentinel: [security improvement] Add CSP header and secure window.open

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing standard security HTTP headers (e.g., X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy) which leaves the application susceptible to basic attacks like MIME-sniffing, clickjacking, and cross-site scripting (XSS).
 **Learning:** In Next.js, standard security headers should be configured globally by returning them from the `async headers()` function in `next.config.ts` to provide defense in depth.
 **Prevention:** Always implement an `async headers()` function in `next.config.ts` returning standard security headers applied to `/(.*)` at the start of any Next.js project.
+
+## 2026-06-29 - Prevent Reverse Tabnabbing and Missing CSP Header
+**Vulnerability:** The application was missing a Content-Security-Policy header in `next.config.ts`, increasing the risk of Cross-Site Scripting (XSS) and data injection. Additionally, `window.open` calls were missing the `noopener,noreferrer` parameters.
+**Learning:** Even static portfolios and low-interaction sites should implement a CSP header as defense in depth against XSS. Further, whenever programmatically opening new windows via `window.open(url, "_blank")`, it's critical to include `"noopener,noreferrer"` to prevent reverse tabnabbing vulnerabilities where the newly opened window could access and manipulate `window.opener`.
+**Prevention:** Include a CSP in the Next.js `headers()` configuration, and always use the third parameter `"noopener,noreferrer"` for `window.open` calls.

--- a/next.config.ts
+++ b/next.config.ts
@@ -33,6 +33,10 @@ const nextConfig: NextConfig = {
             key: "Referrer-Policy",
             value: "strict-origin-when-cross-origin",
           },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https:;",
+          },
         ],
       },
     ];

--- a/src/components/ReceiptPrinter.tsx
+++ b/src/components/ReceiptPrinter.tsx
@@ -139,7 +139,7 @@ const ReceiptPrinter: React.FC<ReceiptPrinterProps> = ({ onClose }) => {
     }, []);
 
     const handleDownload = () => {
-        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank");
+        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank", "noopener,noreferrer");
     };
 
     const handleDiscard = () => {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content-Security-Policy (CSP) HTTP header, which reduces defense-in-depth against Cross-Site Scripting (XSS) and data injection. Additionally, a `window.open` call lacked the `noopener,noreferrer` parameters, creating a potential reverse tabnabbing vulnerability.
🎯 Impact: Without CSP, if an XSS vulnerability exists, attackers could execute malicious scripts or load unauthorized resources. Reverse tabnabbing could allow a maliciously crafted external page to hijack the original window and navigate it to a phishing site.
🔧 Fix: Added a standard CSP header configuration to `next.config.ts`. Updated the `window.open` call in `src/components/ReceiptPrinter.tsx` to include `"noopener,noreferrer"`. Recorded learnings in `.jules/sentinel.md`.
✅ Verification: `pnpm build` completes successfully. Manual code review confirms the header and parameters are in place.

---
*PR created automatically by Jules for task [14395597178187225493](https://jules.google.com/task/14395597178187225493) started by @SudoAnirudh*