### PR TITLE
🛡️ Sentinel: Fix reverse tabnabbing in window.open

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Missing standard security HTTP headers (e.g., X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy) which leaves the application susceptible to basic attacks like MIME-sniffing, clickjacking, and cross-site scripting (XSS).
 **Learning:** In Next.js, standard security headers should be configured globally by returning them from the `async headers()` function in `next.config.ts` to provide defense in depth.
 **Prevention:** Always implement an `async headers()` function in `next.config.ts` returning standard security headers applied to `/(.*)` at the start of any Next.js project.
+## 2025-02-14 - Prevent Reverse Tabnabbing in `window.open`
+**Vulnerability:** A `window.open` call in `src/components/ReceiptPrinter.tsx` omitted the `"noopener,noreferrer"` argument, leaving the application open to reverse tabnabbing attacks where the newly opened window could manipulate `window.opener`.
+**Learning:** Even programmatic navigation needs protection from reverse tabnabbing. It's not limited to just static HTML `<a>` tags.
+**Prevention:** Always use `window.open(url, "_blank", "noopener,noreferrer")` when opening untrusted or external links in a new window/tab.

--- a/src/components/ReceiptPrinter.tsx
+++ b/src/components/ReceiptPrinter.tsx
@@ -139,7 +139,7 @@ const ReceiptPrinter: React.FC<ReceiptPrinterProps> = ({ onClose }) => {
     }, []);
 
     const handleDownload = () => {
-        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank");
+        window.open(portfolioData.hero.actions.find(a => !a.primary)?.href || "#", "_blank", "noopener,noreferrer");
     };
 
     const handleDiscard = () => {


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Reverse Tabnabbing. A `window.open` call in `src/components/ReceiptPrinter.tsx` omitted the `"noopener,noreferrer"` argument, leaving the application open to reverse tabnabbing attacks where the newly opened window could manipulate `window.opener`.
🎯 **Impact:** A maliciously crafted target site could potentially redirect the original application tab to a phishing site or execute malicious scripts in the context of the original application if it had access to `window.opener`.
🔧 **Fix:** Added `"noopener,noreferrer"` as the third parameter to the `window.open` call.
✅ **Verification:** Ran `pnpm lint` and `pnpm build` to ensure no regressions were introduced. The fix correctly passes `noopener,noreferrer` which explicitly denies access to `window.opener`.

---
*PR created automatically by Jules for task [113855794627652149](https://jules.google.com/task/113855794627652149) started by @SudoAnirudh*