### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and fix form associations in RetroMusicPlayer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-02 - Retro UI Component Accessibility Improvement
+**Learning:** When modifying custom retro UI components (e.g., simulated OS windows or media players), explicitly verify that icon-only interactive controls (minimize, close, playback) have descriptive `aria-label` attributes, and internal custom form elements are correctly associated with labels using `id` and `htmlFor`.
+**Action:** Always add `aria-hidden="true"` to text-based icons when using `aria-label` on their parent buttons to prevent double-reading by screen readers.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -124,11 +124,13 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
+                        aria-label="Minimize Player"
                     >_</button>
                     <button 
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
+                        aria-label="Close Player"
                     >X</button>
                 </div>
                 {/* Horizontal Scanlines Overlay on bar */}
@@ -159,21 +161,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button onClick={prevTrack} aria-label="Previous Track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button onClick={togglePlay} aria-label={isPlaying ? "Pause" : "Play"} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button onClick={nextTrack} aria-label="Next Track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to the minimize, close, and all playback buttons inside the `RetroMusicPlayer` component. Set `aria-hidden="true"` on the underlying text-based Material icon spans, and properly linked the volume label to its slider using `id` and `htmlFor`.

🎯 **Why:** To significantly improve accessibility for screen readers navigating the retro desktop components, preventing unhelpful announcements like "skip_previous" or "button".

📸 **Before/After:** No visual change (this is a purely semantic/accessibility update).

♿ **Accessibility:**
* Screen readers will now announce "Minimize Player", "Close Player", "Previous Track", "Play", and "Next Track" instead of reading raw icon names or nothing.
* Screen readers won't double-read the text-based icons.
* The volume slider is now semantically associated with its text label, making it easier to interact with via assistive tech.

---
*PR created automatically by Jules for task [15735900770420158297](https://jules.google.com/task/15735900770420158297) started by @SudoAnirudh*