### PR TITLE
🛡️ Sentinel: [security improvement] Add Permissions-Policy header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+
+## 2026-07-04 - Added Permissions-Policy Security Header
+**Vulnerability:** Missing `Permissions-Policy` header in the application's Next.js configuration, leaving it vulnerable to potential abuse of sensitive browser features (like camera, microphone, geolocation) by third-party scripts.
+**Learning:** Security configurations such as HTTP headers should implement defense-in-depth, strictly limiting what APIs an application can execute, particularly ones with privacy implications.
+**Prevention:** Always verify and include a `Permissions-Policy` header along with standard security HTTP headers in Next.js (`next.config.ts`), strictly disabling unused or sensitive browser APIs.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
🚨 Severity: LOW / ENHANCEMENT
💡 Vulnerability: Missing `Permissions-Policy` header in the application's global Next.js configuration.
🎯 Impact: Without this header, if a cross-site scripting vulnerability or malicious third-party script runs on the page, they could attempt to request access to sensitive browser APIs (like camera, microphone, geolocation), compromising user privacy and safety.
🔧 Fix: Added a `Permissions-Policy` rule to the global HTTP security headers inside `next.config.ts`, explicitly turning off access to `camera`, `microphone`, `geolocation`, and `browsing-topics`.
✅ Verification: Confirmed via `pnpm build` that the configuration compiles cleanly and security headers will be appropriately applied to all routes.

---
*PR created automatically by Jules for task [9853734332878856596](https://jules.google.com/task/9853734332878856596) started by @SudoAnirudh*