### PR TITLE
🎨 Palette: Add focus states and ARIA labels to TV dial controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-04 - Visible Focus Fallbacks for Custom Controls
+**Learning:** When using `focus:outline-none` to suppress default browser outlines on custom icon-only controls (like the TV dials), it inadvertently breaks keyboard accessibility by removing the focus indicator completely.
+**Action:** Always replace raw `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` on interactive elements. This preserves clean mouse interactions while ensuring keyboard navigators can see which element has focus.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -444,18 +444,20 @@ const HelloWorld = () => {
                         <button 
                             onClick={handleNextChannel}
                             title="Change Channel"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Next Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
                         >
-                            <div className="w-full h-1 bg-zinc-950"></div>
+                            <div className="w-full h-1 bg-zinc-950" aria-hidden="true"></div>
                         </button>
                         <button 
                             onClick={handlePrevChannel}
                             title="Fine Tune"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Previous Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
                         >
-                            <div className="w-full h-1 bg-zinc-950"></div>
+                            <div className="w-full h-1 bg-zinc-950" aria-hidden="true"></div>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
💡 **What**: Added `focus-visible` utilities and `aria-label`s to the TV channel and tuning controls in `HelloWorld.tsx`. Replaced `focus:outline-none` with accessible alternatives and ensured the inner decorative elements are hidden from screen readers.
🎯 **Why**: Previously, navigating to the TV controls with a keyboard removed all visual focus indication, making it impossible for keyboard users to know where they were on the screen. The icon-only buttons also lacked text descriptions.
♿ **Accessibility**: Restores keyboard focus visibility without impacting mouse clicks, and provides semantic labels ("Next Channel", "Previous Channel") for screen readers.

---
*PR created automatically by Jules for task [7503293834006900305](https://jules.google.com/task/7503293834006900305) started by @SudoAnirudh*