### PR TITLE
⚡ Bolt: Optimize Next.js Images with sizes attribute

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-07-01 - [Optimize High-Frequency Render Loops]
 **Learning:** For high-frequency render loops (e.g., ASCII animations running every 50-80ms), generating strings via nested array methods (`.map().join()`) creates significant garbage collection overhead and memory thrashing due to continuous allocation of intermediate arrays. In micro-benchmarks, building frames using direct string concatenation in a double `for` loop reduced execution time by approximately 50-60%.
 **Action:** When implementing high-frequency programmatic text/ASCII animations in React, generate the final frame string using standard `for` loops and string concatenation instead of array map/reduce/join operations.
+
+## 2024-05-18 - Missing Sizes on Next.js `<Image fill>`
+**Learning:** When using Next.js `<Image>` with the `fill` property, if the `sizes` attribute is not explicitly provided, Next.js defaults to assuming the image takes up the full viewport width (`100vw`). This leads to the server unnecessarily generating and serving excessively large, unoptimized images to devices with smaller viewports or when the image is contained in a much smaller parent container (e.g., `w-1/3` or `w-64`).
+**Action:** Always map the parent container's responsive width constraints (e.g., Tailwind classes like `md:w-1/3` or grid layouts) to an explicit `sizes` attribute (e.g., `sizes="(max-width: 768px) 100vw, 33vw"`) whenever the `fill` property is used.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -23,11 +23,13 @@ const Education = () => {
 
                 {/* Decorative Pixel Art Image */}
                 <div className="absolute right-0 top-0 w-36 sm:w-52 md:w-64 opacity-20 pointer-events-none h-64">
+                    {/* ⚡ Bolt: Provide sizes to prevent fetching full viewport width (100vw) defaults when using fill */}
                     <Image
                         alt="Retro Pixel Art PC - Education Theme"
                         className="w-full grayscale brightness-110 drop-shadow-2xl rendering-pixelated object-contain"
                         src="/education_overlay.png"
                         fill
+                        sizes="(max-width: 640px) 144px, (max-width: 768px) 208px, 256px"
                     />
                 </div>
             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -36,11 +36,13 @@ const Hero = () => {
                     <div className="flex flex-col md:flex-row gap-6">
                         <div className="w-full md:w-1/3 space-y-4">
                             <div className="aspect-square bg-zinc-300 rounded-xl overflow-hidden border-4 border-zinc-900 shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] relative">
+                                {/* ⚡ Bolt: Added sizes attribute to prevent loading unnecessarily large images since fill layout requires explicit sizes for optimization */}
                                 <Image
                                     alt={`${portfolioData.personal.name} - ${portfolioData.personal.role}`}
                                     className="object-cover grayscale hover:grayscale-0 transition-all duration-500"
                                     src={portfolioData.about.image}
                                     fill
+                                    sizes="(max-width: 768px) 100vw, 33vw"
                                     priority
                                 />
                             </div>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -67,10 +67,12 @@ const Projects = () => {
                                     )}
                                     {project.image ? (
                                         <div className="relative w-full aspect-video border border-black overflow-hidden">
+                                            {/* ⚡ Bolt: Added sizes attribute to Next.js Image with 'fill' for better performance */}
                                             <Image
                                                 src={project.image}
                                                 alt={`Project Thumbnail: ${project.title} - ${project.description.slice(0, 50)}...`}
                                                 fill
+                                                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                                                 className="object-cover grayscale group-hover:grayscale-0 transition-all"
                                             />
                                         </div>


### PR DESCRIPTION
💡 What: Added the `sizes` attribute to Next.js `<Image>` components using the `fill` property in `Hero.tsx`, `Projects.tsx`, and `Education.tsx`.
🎯 Why: Next.js defaults to assuming images with `fill` take up `100vw` (the full viewport width) if no `sizes` attribute is provided. This leads to the server unnecessarily generating and downloading excessively large images for small containers, wasting bandwidth and hurting Core Web Vitals (LCP).
📊 Impact: Expected to reduce initial image payload size and improve LCP by ensuring the browser downloads the correctly sized image from the auto-generated `srcset` based on the defined Tailwind layout constraints.
🔬 Measurement: Verify the generated HTML for the `<img>` tags. The `sizes` attribute should now explicitly guide the browser on what resolution to pick based on screen width, instead of defaulting to 100vw. Tested via `pnpm build` to ensure no compile errors.

---
*PR created automatically by Jules for task [2326979054301848056](https://jules.google.com/task/2326979054301848056) started by @SudoAnirudh*