### PR TITLE
🎨 Palette: Improve accessibility of icon-only interactive controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-07-05 - [Add ARIA labels to Custom Retro UI Controls]
+**Learning:** Custom UI elements like TV knobs and simulated window close buttons often lack inherent text and rely on visual design, making them inaccessible to screen readers. Relying on `title` is insufficient for accessibility. Also, `focus:outline-none` removes keyboard focus visibility, harming navigation.
+**Action:** Explicitly add descriptive `aria-label` attributes to icon-only buttons. Add `aria-hidden="true"` to material-symbol span elements inside buttons. Replace `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` to maintain aesthetics for mouse users while providing clear focus states for keyboard users.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/dev/types/routes.d.ts";
+import "./dist/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -444,7 +444,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handleNextChannel}
                             title="Change Channel"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Next channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>
@@ -452,7 +453,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handlePrevChannel}
                             title="Fine Tune"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Previous channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2213,9 +2213,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
-                        className="hover:bg-red-500 p-1 rounded-none transition-colors"
+                        aria-label="Close project modal"
+                        className="hover:bg-red-500 p-1 rounded-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                     </button>
                 </div>
 


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to custom icon-only interactive controls (the project modal close button and the HelloWorld TV knobs). Added `aria-hidden="true"` to the inner material-symbol spans to prevent redundant screen reader announcements. Replaced generic `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2` fallback styles.

🎯 **Why:** Screen reader users rely on `aria-label`s when an interactive element contains no textual content. Relying purely on a `title` attribute or visual design is not accessible. Furthermore, `focus:outline-none` strips keyboard users of visual indicators of their current active element, making keyboard navigation difficult or impossible.

📸 **Before/After:** Visually identical for standard mouse users, but keyboard users now see clear yellow or white outlines when tabbing into these controls.

♿ **Accessibility:**
- Improved screen reader compatibility for custom UI buttons.
- Restored visual focus indicators for keyboard navigation.

---
*PR created automatically by Jules for task [17805657526266613607](https://jules.google.com/task/17805657526266613607) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus visibility across icon-only controls.
  * Added descriptive labels to buttons used for navigation and closing dialogs.
  * Marked decorative icons as hidden from assistive technologies for cleaner screen reader output.

* **Style**
  * Updated focus styling to use visible focus rings instead of removing outlines.
  * Kept hover and button appearance consistent while improving accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->