### PR TITLE
🎨 Palette: [UX improvement] Enhance accessibility and focus states for modal close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility for Text-Based Icons in Custom Retro UI
+**Learning:** Custom retro UI components (like simulated OS windows) using text-based icon fonts require both `aria-label` on the control and `aria-hidden="true"` on the icon element to prevent redundant or confusing screen reader output, alongside explicit `focus-visible` styling for keyboard navigation.
+**Action:** Always add `aria-hidden="true"` to text-based icons (e.g. material-symbols) inside buttons/links, provide a descriptive `aria-label` on the parent, and ensure a clear `focus-visible` fallback is styled.

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2213,9 +2213,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
-                        className="hover:bg-red-500 p-1 rounded-none transition-colors"
+                        aria-label="Close project modal"
+                        className="hover:bg-red-500 focus-visible:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white p-1 rounded-none transition-colors"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                     </button>
                 </div>
 

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -186,10 +186,10 @@ const Skills = () => {
                                 </div>
                                 <button
                                     onClick={() => setIsModalOpen(false)}
-                                    className="hover:bg-red-500 p-1 rounded-none transition-colors flex items-center justify-center cursor-pointer"
-                                    aria-label="Close modal"
+                                    className="hover:bg-red-500 focus-visible:bg-red-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white p-1 rounded-none transition-colors flex items-center justify-center cursor-pointer"
+                                    aria-label="Close skill details modal"
                                 >
-                                    <span className="material-symbols-outlined text-sm block">close</span>
+                                    <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                                 </button>
                             </div>
 


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the close buttons in the simulated OS window headers (used in `ProjectModal` and `Skills` components).
🎯 **Why:** Icon-only controls using text-based icon fonts (like `material-symbols-outlined`) often cause screen readers to announce the literal text (e.g. "close") and lack clear visual indication for keyboard navigation.
📸 **Before/After:** The buttons now have explicit focus outlines (`focus-visible:ring-2 focus-visible:ring-white focus-visible:bg-red-500`) when tabbed to, whereas before they relied on hover styling and general browser defaults.
♿ **Accessibility:** 
- Added `aria-hidden="true"` to the inner `<span className="material-symbols-outlined">close</span>` element so screen readers don't read "close".
- Added a descriptive `aria-label` on the parent `<button>` for correct screen reader announcement.
- Added `focus-visible` classes so keyboard users can clearly see when the close button has focus.

---
*PR created automatically by Jules for task [12193859655739402009](https://jules.google.com/task/12193859655739402009) started by @SudoAnirudh*