### PR TITLE
🛡️ Sentinel: [security improvement] Add Permissions-Policy Header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2025-02-24 - Missing Permissions-Policy Header
+**Vulnerability:** The application was missing a Permissions-Policy header in next.config.ts.
+**Learning:** While other security headers like CSP were present, defense-in-depth requires explicitly restricting access to sensitive browser features (camera, microphone, geolocation, browsing-topics) to mitigate potential exploitation if a vulnerability like XSS were to occur.
+**Prevention:** Always configure a global Permissions-Policy header alongside other standard security headers to ensure features are disabled by default.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

💡 **Context & Motivation**
While the application already had various standard security headers (like CSP), it was missing a `Permissions-Policy` header.

🎯 **What This PR Does**
- Updates the `next.config.ts` global headers configuration to include the `Permissions-Policy` header.
- Explicitly disables `camera`, `microphone`, `geolocation`, and `browsing-topics` via empty origins `()`.

✅ **Verification**
- Run `pnpm build` to verify the Next.js config remains valid.
- Tested successfully using Node test runner.

---
*PR created automatically by Jules for task [11323675176033346875](https://jules.google.com/task/11323675176033346875) started by @SudoAnirudh*