### PR TITLE
🎨 Palette: Add ARIA labels to RetroMusicPlayer controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-07 - Add ARIA Labels to Custom OS Components
+**Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
+**Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -124,11 +124,13 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <button
                         onClick={() => setIsMinimized(!isMinimized)}
                         className="w-4 h-4 bg-zinc-400 border border-black hover:bg-zinc-200 flex items-center justify-center text-[8px]"
+                        aria-label="Minimize Player"
                     >_</button>
                     <button 
                         onClick={onClose}
                         className="w-4 h-4 bg-red-500 border border-black hover:bg-red-400 flex items-center justify-center text-[8px] text-white"
                         title="Close Player"
+                        aria-label="Close Player"
                     >X</button>
                 </div>
                 {/* Horizontal Scanlines Overlay on bar */}
@@ -159,21 +161,22 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
                     <div className="flex items-center justify-between no-drag">
                         {/* Playback Controls */}
                         <div className="flex gap-1">
-                            <button onClick={prevTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_previous</span>
+                            <button onClick={prevTrack} aria-label="Previous Track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_previous</span>
                             </button>
-                            <button onClick={togglePlay} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-xl">{isPlaying ? "pause" : "play_arrow"}</span>
+                            <button onClick={togglePlay} aria-label={isPlaying ? "Pause" : "Play"} className="w-10 h-10 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-xl" aria-hidden="true">{isPlaying ? "pause" : "play_arrow"}</span>
                             </button>
-                            <button onClick={nextTrack} className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
-                                <span className="material-symbols-outlined text-lg">skip_next</span>
+                            <button onClick={nextTrack} aria-label="Next Track" className="w-8 h-8 bg-zinc-300 border-b-4 border-r-4 border-zinc-600 active:border-0 active:translate-y-1 active:bg-zinc-400 flex items-center justify-center hover:bg-white text-zinc-900">
+                                <span className="material-symbols-outlined text-lg" aria-hidden="true">skip_next</span>
                             </button>
                         </div>
 
                         {/* Volume Slider - Retro Bar Style */}
                         <div className="flex flex-col gap-1 w-20">
-                            <label className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
+                            <label htmlFor="volume-slider" className="text-[8px] text-zinc-500 uppercase font-bold">Volume</label>
                             <input
+                                id="volume-slider"
                                 type="range"
                                 min="0"
                                 max="1"


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only controls (Minimize, Close, Previous Track, Play/Pause, Next Track) in the `RetroMusicPlayer.tsx` component. Also added `aria-hidden="true"` to the inner Material Symbols text spans. Additionally, properly associated the volume slider with its label using `htmlFor` and `id`.

🎯 **Why:** Icon-only buttons without an accessible name are read ambiguously or skipped by screen readers. When using text-based icon fonts, screen readers will read the literal string (like "skip_previous"), which is confusing. This enhances the accessibility for users relying on assistive technologies.

📸 **Before/After:**
*   Before: Buttons relied on visual context or raw icon text strings. The volume label had no programmatic association to the slider input.
*   After: Buttons expose clear actions (e.g., "Next Track", "Minimize Player"). Screen readers ignore the icon font text. The volume slider is properly labeled.

♿ **Accessibility:**
*   Adds robust `aria-label`s to interactable icon buttons.
*   Uses `aria-hidden="true"` to hide decorative icon text from screen readers.
*   Properly associates `<label>` with `<input type="range">` using `htmlFor` and `id`.

---
*PR created automatically by Jules for task [5024403286999457063](https://jules.google.com/task/5024403286999457063) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and screen reader support for the floating music player controls.
  * Added clear labels to icon-only buttons and hidden decorative icons from assistive technology.
  * Linked the volume label directly to its slider for better form accessibility.
* **Documentation**
  * Added updated accessibility guidance for custom retro UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->