### PR TITLE
🛡️ Sentinel: [security improvement] Add Permissions-Policy header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2025-02-21 - Missing Permissions-Policy header
+**Vulnerability:** The application was missing a Permissions-Policy header, which is a defense-in-depth mechanism against unauthorized access to sensitive web APIs like camera, microphone, geolocation, and browsing-topics.
+**Learning:** Next.js global headers should always include a Permissions-Policy configuration to restrict unnecessary API access.
+**Prevention:** Always verify that standard security headers, specifically Permissions-Policy, are explicitly defined in Next.js configuration.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
Adds a `Permissions-Policy` HTTP header in `next.config.ts` to restrict access to sensitive web APIs (camera, microphone, geolocation, and browsing-topics). This provides an additional layer of defense in depth against potentially malicious scripts or compromised third-party code silently accessing device features.

Also logs this important defense-in-depth security learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7692180477319452642](https://jules.google.com/task/7692180477319452642) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a `Permissions-Policy` response header site-wide to better restrict access to sensitive browser features.
  * Reduced exposure of camera, microphone, geolocation, and browsing-topics capabilities.

* **Documentation**
  * Updated security notes with guidance on keeping the policy configured globally for stronger protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->