### PR TITLE
🎨 Palette: Improve keyboard navigation focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2024-07-08 - Accessible Keyboard Navigation Focus Fallbacks
+**Learning:** Hardcoding `focus:outline-none` to remove native focus rings causes critical accessibility regressions for keyboard users when navigating custom interactive UI components.
+**Action:** Always replace `focus:outline-none` with `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` on interactive components to preserve visual focus state without compromising mouse interactions.

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,37 @@
+<<<<<<< SEARCH
+                        <button
+                            onClick={handleNextChannel}
+                            title="Change Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
+                        >
+                            <div className="w-full h-1 bg-zinc-950"></div>
+                        </button>
+                        <button
+                            onClick={handlePrevChannel}
+                            title="Fine Tune"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
+                        >
+                            <div className="w-full h-1 bg-zinc-950"></div>
+                        </button>
+=======
+                        <button
+                            onClick={handleNextChannel}
+                            title="Change Channel"
+                            aria-label="Change Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-800"
+                            style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
+                        >
+                            <div className="w-full h-1 bg-zinc-950"></div>
+                        </button>
+                        <button
+                            onClick={handlePrevChannel}
+                            title="Fine Tune"
+                            aria-label="Fine Tune"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-800"
+                            style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
+                        >
+                            <div className="w-full h-1 bg-zinc-950"></div>
+                        </button>
+>>>>>>> REPLACE

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -459,7 +459,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handleNextChannel}
                             title="Change Channel"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Change Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-800"
                             style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>
@@ -467,7 +468,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handlePrevChannel}
                             title="Fine Tune"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Fine Tune"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-800"
                             style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -124,7 +124,7 @@ const Skills = () => {
                                                 setSelectedSkill(skill);
                                                 setIsModalOpen(true);
                                             }}
-                                            className="flex flex-col items-center justify-center gap-1 group focus:outline-none cursor-pointer relative z-20"
+                                            className="flex flex-col items-center justify-center gap-1 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow rounded cursor-pointer relative z-20"
                                             aria-label={`Inspect details for ${skill}`}
                                         >
                                             <div className="w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center bg-zinc-800 border-2 border-zinc-600 rounded p-1.5 group-hover:scale-110 group-hover:border-retro-yellow group-hover:shadow-[0_0_12px_rgba(253,224,71,0.4)] transition-all cursor-help relative" title={skill}>


### PR DESCRIPTION
💡 **What**:
- Replaced `focus:outline-none` with explicit `focus-visible:ring-*` classes on interactive custom components in `HelloWorld.tsx` and `Skills.tsx`.
- Added missing `aria-label`s to the TV channel changing buttons in `HelloWorld.tsx`.
- Documented this accessible keyboard navigation insight in `.jules/palette.md`.

🎯 **Why**:
- Hardcoding `focus:outline-none` without providing a focus fallback makes interactive elements entirely invisible to keyboard navigators. This restores crucial accessibility features without compromising the desired visual aesthetic for mouse users. 

📸 **Before/After**:
- Before: Hitting `Tab` to navigate custom controls showed no visual indication of focus.
- After: Hitting `Tab` outlines the currently selected control with a distinct `retro-yellow` focus ring.

♿ **Accessibility**:
- Fixed critical keyboard navigation regression (focus loss) on multiple UI components.
- Provided explicit accessible names (`aria-label`) to non-text buttons (TV controls) ensuring they can be read properly by screen readers rather than relying purely on the `title` attribute.

---
*PR created automatically by Jules for task [2596194342983574530](https://jules.google.com/task/2596194342983574530) started by @SudoAnirudh*