### PR TITLE
⚡ Bolt: [Add sizes attribute to fill Images for optimized delivery]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2026-07-02 - [Cache AudioContext and AudioBuffer to Prevent Crashes and Overhead]
 **Learning:** Browsers enforce a strict limit on the number of concurrently active \`AudioContext\` instances (~6). Repeatedly instantiating \`new window.AudioContext()\` on events like clicks or hover will quickly lead to hardware limit crashes ("Failed to construct 'AudioContext': The number of hardware contexts provided..."). Additionally, repeatedly allocating \`AudioBuffer\` and looping through \`getChannelData\` for white noise on every play triggers garbage collection overhead and drops frames in high-frequency triggers.
 **Action:** When implementing sound effects using the Web Audio API, always lazily initialize and cache a single module-level or global \`AudioContext\` singleton. For static or algorithmically generated sound buffers (like white noise), compute and cache the \`AudioBuffer\` once rather than re-allocating and re-calculating the buffer on every invocation.
+
+## 2026-07-08 - [Optimize Next.js Images with `fill` property]
+**Learning:** When using the Next.js `<Image>` component with the `fill` property, omitting the `sizes` attribute causes the browser to download unnecessarily large, unoptimized images for smaller viewports, severely impacting performance on mobile devices.
+**Action:** Always provide a `sizes` attribute (e.g., `sizes="(max-width: 768px) 100vw, 33vw"`) when using `fill` to ensure responsive and optimized image delivery based on the container's responsive CSS layout.

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -28,6 +28,8 @@ const Education = () => {
                         className="w-full grayscale brightness-110 drop-shadow-2xl rendering-pixelated object-contain"
                         src="/education_overlay.png"
                         fill
+                        // ⚡ Bolt: Added sizes attribute to prevent serving unoptimized full-size images to smaller devices
+                        sizes="(max-width: 640px) 144px, (max-width: 768px) 208px, 256px"
                     />
                 </div>
             </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -42,6 +42,8 @@ const Hero = () => {
                                     src={portfolioData.about.image}
                                     fill
                                     priority
+                                    // ⚡ Bolt: Added sizes attribute to prevent serving unoptimized full-size images to smaller devices
+                                    sizes="(max-width: 768px) 100vw, 33vw"
                                 />
                             </div>
                             <div className="bg-primary text-black font-display text-center py-2 rounded-full text-sm border-2 border-black font-bold uppercase tracking-widest hover:bg-retro-yellow transition-colors">

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -72,6 +72,8 @@ const Projects = () => {
                                                 alt={`Project Thumbnail: ${project.title} - ${project.description.slice(0, 50)}...`}
                                                 fill
                                                 className="object-cover grayscale group-hover:grayscale-0 transition-all"
+                                                // ⚡ Bolt: Added sizes attribute to prevent serving unoptimized full-size images to smaller devices in grid layout
+                                                sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                                             />
                                         </div>
                                     ) : (


### PR DESCRIPTION
💡 **What:** Added `sizes` attributes to `next/image` components that utilize the `fill` layout property across `Hero.tsx`, `Projects.tsx`, and `Education.tsx`.

🎯 **Why:** When `next/image` is used with `fill`, Next.js doesn't know the CSS-defined dimensions of the image. By default, it assumes the image will occupy the entire viewport (`100vw`). This results in browsers on smaller devices downloading unnecessarily large images (e.g., fetching a 1080p image for a 300px wide container on mobile), severely impacting performance and LCP (Largest Contentful Paint).

📊 **Impact:** Reduces unoptimized large image fetching on mobile viewports. On smaller screens, the browser will request specifically sized images (e.g. `33vw` instead of `100vw`), drastically saving network bandwidth.

🔬 **Measurement:** Verify by building the app (`pnpm build`) and opening dev tools network tab. Note the sizes of images being requested on a mobile viewport vs desktop viewport; smaller optimized images will be fetched for mobile.

---
*PR created automatically by Jules for task [4592151587664379830](https://jules.google.com/task/4592151587664379830) started by @SudoAnirudh*