### PR TITLE
🛡️ Sentinel: [security improvement] Add Permissions-Policy Header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2025-02-21 - Add Permissions-Policy Security Header
+**Vulnerability:** Missing `Permissions-Policy` header leaves the application susceptible to unauthorized access to sensitive browser features (like camera, microphone, geolocation).
+**Learning:** It is crucial to restrict access to sensitive browser features explicitly to minimize the attack surface, especially for modern applications.
+**Prevention:** Always include a `Permissions-Policy` header in Next.js global configuration alongside other standard security headers to enforce explicit access control to browser features.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Missing `Permissions-Policy` header leaves the application susceptible to unauthorized access to sensitive browser features (like camera, microphone, geolocation) in case of other vulnerabilities like XSS.
**Impact:** If an XSS vulnerability is exploited, attackers could potentially access these features if they aren't explicitly denied by the policy.
**Fix:** Added the `Permissions-Policy` header to the global headers array in `next.config.ts` with the value `'camera=(), microphone=(), geolocation=(), browsing-topics=()'`, explicitly denying access to these features.
**Verification:** Run `pnpm build` and `pnpm start`, then inspect the HTTP response headers of any page to verify the presence of the `Permissions-Policy` header.

---
*PR created automatically by Jules for task [16042631581516463646](https://jules.google.com/task/16042631581516463646) started by @SudoAnirudh*