### PR TITLE
🎨 Palette: [UX improvement] Add keyboard focus rings and ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2024-05-24 - Provide focus-visible fallbacks
+**Learning:** Using `focus:outline-none` without providing alternative focus styles makes interactive elements completely invisible to keyboard users when navigating.
+**Action:** Always replace `focus:outline-none` with accessible alternatives like `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow` to maintain design aesthetics while preserving keyboard accessibility.

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -459,18 +459,20 @@ const HelloWorld = () => {
                         <button 
                             onClick={handleNextChannel}
                             title="Change Channel"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Change Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
                             style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
                         >
-                            <div className="w-full h-1 bg-zinc-950"></div>
+                            <div className="w-full h-1 bg-zinc-950" aria-hidden="true"></div>
                         </button>
                         <button 
                             onClick={handlePrevChannel}
                             title="Fine Tune"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Fine Tune"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
                             style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
                         >
-                            <div className="w-full h-1 bg-zinc-950"></div>
+                            <div className="w-full h-1 bg-zinc-950" aria-hidden="true"></div>
                         </button>
                     </div>
                 </div>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -124,7 +124,7 @@ const Skills = () => {
                                                 setSelectedSkill(skill);
                                                 setIsModalOpen(true);
                                             }}
-                                            className="flex flex-col items-center justify-center gap-1 group focus:outline-none cursor-pointer relative z-20"
+                                            className="flex flex-col items-center justify-center gap-1 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow rounded-lg focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900 cursor-pointer relative z-20"
                                             aria-label={`Inspect details for ${skill}`}
                                         >
                                             <div className="w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center bg-zinc-800 border-2 border-zinc-600 rounded p-1.5 group-hover:scale-110 group-hover:border-retro-yellow group-hover:shadow-[0_0_12px_rgba(253,224,71,0.4)] transition-all cursor-help relative" title={skill}>


### PR DESCRIPTION
💡 What: Replaced raw `focus:outline-none` on interactive elements in `HelloWorld.tsx` and `Skills.tsx` with accessible `focus-visible` ring fallbacks, and added `aria-label`s to icon-only buttons.
🎯 Why: To ensure keyboard users can visually see which element has focus while maintaining the intended aesthetic, and screen reader users can understand icon-only buttons.
📸 Before/After: Interactive elements now display a retro-yellow focus ring when navigated via keyboard.
♿ Accessibility: Improves keyboard navigation tracking and screen reader label context.

---
*PR created automatically by Jules for task [7758996696004930118](https://jules.google.com/task/7758996696004930118) started by @SudoAnirudh*