### PR TITLE
🎨 Palette: Keyboard accessible Project cards & modal

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-07-10 - Keyboard Accessibility for Custom Interactive Divs
+**Learning:** When turning a div into an interactive element, missing keyboard event handlers (Enter/Space) and missing focus indicators prevent keyboard users from accessing the functionality. Using `group-focus-visible` alongside `group-hover` is necessary to synchronize the interaction visuals.
+**Action:** Replaced `onClick`-only divs with `role="button"`, added `tabIndex={0}`, an `onKeyDown` handler for keyboard activation, and applied `group-focus-visible` styling to ensure a consistent experience.

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2213,9 +2213,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
-                        className="hover:bg-red-500 p-1 rounded-none transition-colors"
+                        aria-label="Close Project Details"
+                        className="hover:bg-red-500 p-1 rounded-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2 focus-visible:ring-offset-retro-charcoal"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                     </button>
                 </div>
 

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -56,10 +56,19 @@ const Projects = () => {
                         return (
                             <div
                                 key={index}
-                                className="group cursor-pointer"
+                                role="button"
+                                tabIndex={0}
+                                aria-label={`View details for ${project.title}`}
+                                className="group cursor-pointer focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-retro-orange focus-visible:ring-offset-2"
                                 onClick={() => handleOpenProject(project, index)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        handleOpenProject(project, index);
+                                    }
+                                }}
                             >
-                                <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
+                                <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow group-focus-visible:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-focus-visible:translate-x-[2px] group-focus-visible:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] group-focus-visible:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                     {isOngoing && (
                                         <div className="absolute top-4 right-4 z-10 bg-retro-orange border-2 border-black px-2 py-0.5 text-[8px] font-pixel uppercase tracking-wider text-black shadow-[2px_2px_0px_0px_rgba(0,0,0,1)] select-none">
                                             Ongoing
@@ -72,12 +81,12 @@ const Projects = () => {
                                                 alt={`Project Thumbnail: ${project.title} - ${project.description.slice(0, 50)}...`}
                                                 fill
                                                 sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
-                                                className="object-cover grayscale group-hover:grayscale-0 transition-all"
+                                                className="object-cover grayscale group-hover:grayscale-0 group-focus-visible:grayscale-0 transition-all"
                                             />
                                         </div>
                                     ) : (
                                         <div className="w-full aspect-video flex items-center justify-center bg-retro-charcoal/5 border border-black">
-                                            <span className="material-symbols-outlined text-6xl text-retro-charcoal/20 group-hover:text-retro-charcoal transition-colors">{project.icon}</span>
+                                            <span className="material-symbols-outlined text-6xl text-retro-charcoal/20 group-hover:text-retro-charcoal group-focus-visible:text-retro-charcoal transition-colors">{project.icon}</span>
                                         </div>
                                     )}
                                 </div>
@@ -89,10 +98,10 @@ const Projects = () => {
                                     <div className="text-xs font-body text-zinc-500 truncate px-2">
                                         {project.title.toLowerCase()}.exe
                                     </div>
-                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
+                                        <span className="text-xs font-bold uppercase underline group-hover:text-retro-orange group-focus-visible:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
💡 What: Converted the Project card `div` elements into accessible buttons with `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler. Also updated the Project Modal close button with an `aria-label` and `aria-hidden` on the inner icon. Synchronized focus states with `focus-visible`.
🎯 Why: Previously, users relying on keyboards could not tab to, explore, or close project cards since they were built as non-interactive `div`s and icon-only buttons lacked accessible names.
📸 Before/After: Visual focus rings now match the existing hover styles for consistency.
♿ Accessibility: Added `role="button"`, `tabIndex={0}`, `aria-label`, and `onKeyDown` for keyboard interactions. Added `aria-label` to the modal close button.

---
*PR created automatically by Jules for task [7741289651765413618](https://jules.google.com/task/7741289651765413618) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Project cards can now be opened using Enter or Space, with improved keyboard focus indicators.
  * Added accessible labels to project cards and the modal close control.
  * Decorative close icons are now hidden from screen readers.
  * Improved hover and focus visibility for interactive project controls.

* **Documentation**
  * Added guidance for making custom interactive elements keyboard accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->