### PR TITLE
🎨 Palette: Add focus visible styles and ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2024-07-11 - Replace focus:outline-none with focus-visible fallbacks
+**Learning:** Using `focus:outline-none` removes the default focus indicator, which hurts keyboard navigation accessibility if no visible fallback is provided. Interactive elements should use `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow` to ensure users navigating via keyboard can see which element is active.
+**Action:** Always replace `focus:outline-none` on interactive elements with `focus-visible` styles that provide a clear visual indicator.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/types/routes.d.ts";
+import "./dist/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/HelloWorld.tsx
+++ b/src/components/HelloWorld.tsx
@@ -459,7 +459,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handleNextChannel}
                             title="Change Channel"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Next Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${(channel - 3) * 90}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>
@@ -467,7 +468,8 @@ const HelloWorld = () => {
                         <button 
                             onClick={handlePrevChannel}
                             title="Fine Tune"
-                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus:outline-none"
+                            aria-label="Previous Channel"
+                            className="w-6 h-6 rounded-full bg-zinc-800 border-2 border-zinc-600 flex items-center justify-center shadow-lg transition-all duration-300 active:scale-95 cursor-pointer hover:border-retro-yellow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                             style={{ transform: `rotate(${-((channel - 3) * 45)}deg)` }}
                         >
                             <div className="w-full h-1 bg-zinc-950"></div>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -124,7 +124,7 @@ const Skills = () => {
                                                 setSelectedSkill(skill);
                                                 setIsModalOpen(true);
                                             }}
-                                            className="flex flex-col items-center justify-center gap-1 group focus:outline-none cursor-pointer relative z-20"
+                                            className="flex flex-col items-center justify-center gap-1 group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow cursor-pointer relative z-20 rounded"
                                             aria-label={`Inspect details for ${skill}`}
                                         >
                                             <div className="w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center bg-zinc-800 border-2 border-zinc-600 rounded p-1.5 group-hover:scale-110 group-hover:border-retro-yellow group-hover:shadow-[0_0_12px_rgba(253,224,71,0.4)] transition-all cursor-help relative" title={skill}>


### PR DESCRIPTION
## 💡 What
Replaced hardcoded `focus:outline-none` classes with accessible `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow` fallbacks in `src/components/HelloWorld.tsx` and `src/components/Skills.tsx`. Additionally, added descriptive `aria-label` attributes to the icon-only "Change Channel" and "Fine Tune" TV control buttons. 

## 🎯 Why
`focus:outline-none` completely removes the browser's default focus ring, making it impossible for keyboard-only users to see which element is currently focused. Replacing it with `focus-visible` ensures that mouse users don't see ugly focus rings when clicking, while keyboard users are provided with a clear, themed visual indicator (`retro-yellow` ring).

## 📸 Before/After
**Before:** Tabbing to the TV channel buttons or the Skill icons resulted in no visual change, making keyboard navigation impossible.
**After:** Tabbing to these elements now displays a prominent yellow focus ring around the component.

## ♿ Accessibility
- Fixed WCAG 2.4.7 Focus Visible violations on interactive elements.
- Fixed WCAG 4.1.2 Name, Role, Value violations on icon-only buttons by adding ARIA labels.

---
*PR created automatically by Jules for task [3717156707416387330](https://jules.google.com/task/3717156707416387330) started by @SudoAnirudh*