### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing Permissions-Policy header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2026-07-12 - [Missing Permissions-Policy Header]
+**Vulnerability:** The application was missing the `Permissions-Policy` header, allowing potential access to sensitive browser features like camera, microphone, geolocation, and browsing topics.
+**Learning:** In Next.js, defense-in-depth security headers like `Permissions-Policy` should be explicitly added to `next.config.ts` via the `headers()` function to restrict browser feature access.
+**Prevention:** Always verify and include a strict `Permissions-Policy` in the global application headers configuration to proactively disable unnecessary and sensitive browser features.

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,10 @@ const nextConfig: NextConfig = {
             key: "Content-Security-Policy",
             value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; media-src 'self' data: https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
+          {
+            key: "Permissions-Policy",
+            value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
         ],
       },
     ];


### PR DESCRIPTION
## 🛡️ Sentinel: [HIGH] Fix missing Permissions-Policy header

**🚨 Severity:** HIGH
**💡 Vulnerability:** The application was missing the `Permissions-Policy` security header in the global Next.js configuration.
**🎯 Impact:** Without this header, the application is unnecessarily permitted by the browser to access sensitive APIs (camera, microphone, geolocation, etc.). In the event of a successful XSS attack, an attacker could potentially abuse these permissions.
**🔧 Fix:** Added the `Permissions-Policy` header to the `async headers()` array in `next.config.ts`, explicitly disabling `camera`, `microphone`, `geolocation`, and `browsing-topics` (`=()`).
**✅ Verification:** Verified syntax using `pnpm build`, `pnpm lint`, and unit tests (`node --test`), which all pass successfully.

---
*PR created automatically by Jules for task [13319267835618346438](https://jules.google.com/task/13319267835618346438) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Added a strict `Permissions-Policy` HTTP header to restrict access to camera, microphone, geolocation, and browsing-topics browser capabilities.
* **Documentation**
  * Added security guidance documenting the missing header and recommended prevention measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->