### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to Project Modal close button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-18 - Form and Social Links Accessibility Improvements
 **Learning:** In the `Contact.tsx` component, form inputs were relying solely on placeholders without `<label>` elements, which breaks screen reader support. Social icons were missing `aria-label`s, and text inside `span` with `material-symbols-outlined` was being read by screen readers.
 **Action:** Always provide `<label>` elements (using `sr-only` class if they should be visually hidden) for inputs, associate error states using `aria-invalid` and `aria-describedby`, add `aria-label` to icon-only links, and use `aria-hidden="true"` on the internal icon elements to prevent redundant reading. Also ensure external links include `target="_blank" rel="noopener noreferrer"` for security.
+
+## 2025-06-15 - Missing ARIA Labels on Modal Close Buttons
+**Learning:** Icon-only close buttons in modal components often lack `aria-label` attributes, and their inner text-based icons lack `aria-hidden="true"`, causing screen readers to incorrectly read the icon text.
+**Action:** When adding or reviewing modals, ensure the close button has an `aria-label` (e.g., `aria-label="Close modal"`) and any inner text-based icons (like `material-symbols-outlined`) have `aria-hidden="true"`.

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2213,9 +2213,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
+                        aria-label="Close modal"
                         className="hover:bg-red-500 p-1 rounded-none transition-colors"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span aria-hidden="true" className="material-symbols-outlined text-sm block">close</span>
                     </button>
                 </div>
 


### PR DESCRIPTION
💡 What: Added an `aria-label="Close modal"` to the close button in `ProjectModal.tsx` and added `aria-hidden="true"` to its inner `<span className="material-symbols-outlined">`.

🎯 Why: The close button in the Project Modal was an icon-only button without an `aria-label`, meaning screen readers would read the literal text "close" instead of conveying the button's action. This improves the accessibility of the modal.

📸 Before/After: Visual changes are not applicable as this is an accessibility improvement that only affects screen readers.

♿ Accessibility: 
- Screen readers will now announce the button as "Close modal" instead of "close".
- The decorative icon text is correctly hidden from screen readers.

---
*PR created automatically by Jules for task [2392073321934781176](https://jules.google.com/task/2392073321934781176) started by @SudoAnirudh*