### PR TITLE
🎨 Palette: Add accessible aria-label and focus state to Project Modal close button

### DIFF
--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2213,9 +2213,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
-                        className="hover:bg-red-500 p-1 rounded-none transition-colors"
+                        aria-label="Close modal"
+                        className="hover:bg-red-500 p-1 rounded-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                     </button>
                 </div>
 


### PR DESCRIPTION
💡 **What:** 
Added an `aria-label` and `focus-visible` states to the "Close" button in the `ProjectModal` component. 

🎯 **Why:** 
The close button was previously an icon-only button lacking an accessible name, making it inaccessible to screen reader users. Furthermore, keyboard users could not easily identify when the button was focused. This small addition makes the primary escape hatch of the modal fully accessible.

📸 **Before/After:**
*(See Playwright verification screenshots)*
- **Before:** Keyboard focus would apply a default browser ring (if any) and screen readers would read "close" from the Material Symbols text, which isn't always reliable.
- **After:** Keyboard focus applies a crisp, customized `ring-white` (since it's on a dark header), and screen readers explicitly announce "Close modal".

♿ **Accessibility:** 
- Adds `aria-label="Close modal"` to the `<button>`.
- Adds `aria-hidden="true"` to the inner `<span className="material-symbols-outlined">`.
- Adds `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white` for explicit keyboard focus indication.

---
*PR created automatically by Jules for task [10275080533760855989](https://jules.google.com/task/10275080533760855989) started by @SudoAnirudh*