### PR TITLE
⚡ Bolt: Cache DOM targets in high-frequency mousemove events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2026-07-09 - [Optimize Next.js Images with sizes attribute]
 **Learning:** When using Next.js <Image> with the `fill` property, omitting the `sizes` attribute causes Next.js to serve unnecessarily large, unoptimized images to smaller viewports because it assumes the image will take up the full width of the screen. This increases bandwidth usage and slows down page load times, especially on mobile devices.
 **Action:** Always provide a `sizes` attribute (e.g., `sizes="(max-width: 768px) 100vw, 33vw"`) when using the `fill` property on the Next.js <Image> component to ensure the browser requests the correctly sized image based on the current viewport.
+
+## 2026-07-18 - [Cache event.target in high-frequency events]
+**Learning:** In high-frequency listeners like `mousemove`, calculating `target.closest()` and `getComputedStyle()` every time causes massive layout thrashing and CPU overhead.
+**Action:** Cache the `e.target` element in a `useRef` and only run expensive traversals/recalculations when the target changes.

--- a/src/components/RetroCursor.tsx
+++ b/src/components/RetroCursor.tsx
@@ -10,6 +10,7 @@ const RetroCursor = () => {
     const [isVisible, setIsVisible] = useState(false);
 
     const mousePos = useRef({ x: 0, y: 0 });
+    const lastTargetRef = useRef<EventTarget | null>(null);
 
     useEffect(() => {
         // Only run on client and non-touch devices
@@ -29,6 +30,12 @@ const RetroCursor = () => {
 
         const updateMousePos = (e: MouseEvent) => {
             mousePos.current = { x: e.clientX, y: e.clientY };
+
+            // Optimization: Skip expensive DOM/style checks if target hasn't changed
+            if (e.target === lastTargetRef.current) {
+                return;
+            }
+            lastTargetRef.current = e.target;
 
             // Interaction Check for clickable items
             const target = e.target as HTMLElement;


### PR DESCRIPTION
💡 **What:** 
Added a `lastTargetRef` (`useRef`) to cache the `e.target` element during the `mousemove` event in `RetroCursor.tsx`. The interaction checks (`.closest()` and `getComputedStyle()`) are now skipped if the mouse is moving over the exact same element as the previous frame.

🎯 **Why:** 
The custom cursor evaluates whether the hovered element is interactive on every pixel of movement. Functions like `target.closest()` and especially `getComputedStyle(target)` are expensive. Running them continuously on high-frequency events causes massive layout thrashing, style recalculation overhead, and increased CPU usage, making the site feel sluggish on lower-end devices.

📊 **Impact:** 
Eliminates redundant DOM traversal and style recalculations on every `mousemove` event when the user is simply moving the mouse within the boundaries of a single element. This significantly smooths out interaction and frees up the main thread.

🔬 **Measurement:** 
1. Use Chrome DevTools Performance Profiler.
2. Record a session while wildly moving the mouse over empty space or large non-interactive text blocks.
3. Compare the time spent in "Recalculate Style" and "Function Call (`updateMousePos`)". The execution time drops to near-zero for continuous movement over the same element.

---
*PR created automatically by Jules for task [10401316105970144472](https://jules.google.com/task/10401316105970144472) started by @SudoAnirudh*