### PR TITLE
🎨 Palette: Improve Project Card Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2024-05-31 - Fix Project Card Accessibility
+**Learning:** Interactive cards must use semantic `<button>` elements without nested interactive elements to ensure native keyboard focus and correct screen reader behavior.
+**Action:** Replace `div` onClick wrappers with semantic buttons, add `aria-label`, visible focus states, and replace inner buttons with `span` elements.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/types/routes.d.ts";
+import "./dist/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -54,10 +54,11 @@ const Projects = () => {
                         );
 
                         return (
-                            <div
+                            <button
                                 key={index}
-                                className="group cursor-pointer"
+                                className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-retro-yellow focus-visible:ring-offset-2"
                                 onClick={() => handleOpenProject(project, index)}
+                                aria-label={`View details for ${project.title}`}
                             >
                                 <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                     {isOngoing && (
@@ -89,13 +90,13 @@ const Projects = () => {
                                     <div className="text-xs font-body text-zinc-500 truncate px-2">
                                         {project.title.toLowerCase()}.exe
                                     </div>
-                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
+                                        <span className="text-xs font-bold uppercase underline group-hover:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
💡 **What:** Replaced the `div` wrapper around project cards with a semantic `<button>` element and removed the nested `<button>`.
🎯 **Why:** Ensures the interactive cards are natively focusable via keyboard, behave correctly with screen readers, and do not violate HTML validity rules regarding nested interactive elements.
📸 **Before/After:** The visual appearance remains exactly the same, but keyboard users can now tab to the card and will see a focus ring, rather than being unable to focus it or having focus land on the nested sub-button.
♿ **Accessibility:** Added ARIA labels based on the project title, enabled native tab navigation, introduced a clear `focus-visible` ring using existing tokens, and removed the nested `<button>` which can confuse screen readers.

---
*PR created automatically by Jules for task [17673849086167296982](https://jules.google.com/task/17673849086167296982) started by @SudoAnirudh*