### PR TITLE
🛡️ Sentinel: Add client-side maxLength validation to prevent oversized payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+
+## 2024-07-19 - Missing Client-Side Input Length Limits
+**Vulnerability:** The contact form inputs (name, email, message) lacked `maxLength` attributes, allowing arbitrarily large strings to be typed into the form.
+**Learning:** Client-side constraints must explicitly align with server-side validations to prevent DoS via oversized payloads.
+**Prevention:** Always add `maxLength` attributes to form inputs (e.g., `<input maxLength={100}>`) corresponding to the max length on the server.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -272,6 +272,7 @@ const Contact = () => {
                                                 className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400"
                                                 placeholder="ENTER NAME..."
                                                 type="text"
+                                                maxLength={100}
                                                 required
                                             />
                                         </div>
@@ -285,6 +286,7 @@ const Contact = () => {
                                                 className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
+                                                maxLength={255}
                                                 aria-invalid={!!emailError}
                                                 aria-describedby={emailError ? "email-error" : undefined}
                                                 required
@@ -300,6 +302,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
                                                 placeholder="TYPE YOUR MESSAGE HERE..."
+                                                maxLength={5000}
                                                 required
                                             ></textarea>
                                         </div>


### PR DESCRIPTION
**Severity:** MEDIUM
**Vulnerability:** Missing client-side input length limits. The contact form inputs (name, email, message) lacked `maxLength` attributes, allowing arbitrarily large strings to be typed into the form before reaching the server.
**Impact:** Potential DoS via resource exhaustion from oversized payloads, as well as degraded user experience if the server simply rejects massive inputs after submission.
**Fix:** Added `maxLength` attributes to form inputs (`name`: 100, `email`: 255, `message`: 5000) that correspond directly to the maximum length enforced by the server.
**Verification:** Inspected inputs, successfully ran `pnpm build`, and ran tests (`node --test`).

---
*PR created automatically by Jules for task [12399870514389388953](https://jules.google.com/task/12399870514389388953) started by @SudoAnirudh*