### PR TITLE
🛡️ Sentinel: [security improvement] Enforce Client-Side Input Length Limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2024-05-24 - Enforce Client-Side Input Length Limits
+**Vulnerability:** The contact form lacked client-side `maxLength` attributes, allowing potentially massive payloads to be sent to the server, risking application-layer DoS.
+**Learning:** Always align client-side form input constraints with server-side validation logic to prevent oversized payloads from reaching the backend.
+**Prevention:** Add `maxLength` attributes to all text inputs and textareas that correspond to backend length limits.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -272,6 +272,7 @@ const Contact = () => {
                                                 className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400"
                                                 placeholder="ENTER NAME..."
                                                 type="text"
+                                                maxLength={100}
                                                 required
                                             />
                                         </div>
@@ -285,6 +286,7 @@ const Contact = () => {
                                                 className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
                                                 type="email"
+                                                maxLength={255}
                                                 aria-invalid={!!emailError}
                                                 aria-describedby={emailError ? "email-error" : undefined}
                                                 required
@@ -300,6 +302,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
                                                 placeholder="TYPE YOUR MESSAGE HERE..."
+                                                maxLength={5000}
                                                 required
                                             ></textarea>
                                         </div>


### PR DESCRIPTION
This PR introduces a security enhancement to the contact form by adding client-side `maxLength` attributes to the Name (100), Email (255), and Message (5000) fields.

**Security Context:**
*   **Vulnerability/Risk:** The contact form previously lacked client-side input length constraints. While server-side validation is in place (`src/app/actions/contact.ts`), missing client-side constraints allow oversized payloads to be transmitted over the network and processed by the server, representing a rudimentary application-layer Denial of Service (DoS) vector.
*   **Fix:** Added `maxLength` to all fields in `src/components/Contact.tsx` explicitly aligning them with the enforced server-side limits.
*   **Impact:** Reduces unnecessary network payload sizes and prevents trivially large requests from reaching the backend application logic.

**Verification:**
*   Ran `pnpm lint`, `pnpm build`, and `node --test` to ensure no regressions.
*   Verified that the max lengths perfectly align with the checks in `src/app/actions/contact.ts`.

---
*PR created automatically by Jules for task [10168271861316214902](https://jules.google.com/task/10168271861316214902) started by @SudoAnirudh*