### PR TITLE
⚡ Bolt: [Prevent unnecessary re-renders in RetroCursor idle state]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-07-17 - [Cache DOM target in high-frequency event listeners]
 **Learning:** In high-frequency event listeners like `mousemove`, constantly re-evaluating expensive DOM traversals (e.g., `.closest()`) and recalculating styles (e.g., `getComputedStyle()`) on every pixel movement causes significant layout thrashing and CPU overhead.
 **Action:** Always cache the current DOM target (`e.target`) and only perform expensive checks when the target element actually changes.
+
+## 2026-07-21 - [Prevent Unnecessary State Updates in RequestAnimationFrame]
+**Learning:** Calling React state setters like `setTrail` inside a continuous `requestAnimationFrame` loop causes ~60 re-renders per second even when there is no actual state change (e.g., when the mouse is idle). This constant re-rendering of complex SVG elements causes significant CPU overhead and drains battery on laptops.
+**Action:** Always track actual value changes (e.g., using a `hasMoved` flag with a small epsilon check like `> 0.1`) and wrap React state setters in conditional checks to bypass re-renders entirely during idle states.

--- a/src/components/RetroCursor.tsx
+++ b/src/components/RetroCursor.tsx
@@ -59,15 +59,20 @@ const RetroCursor = () => {
         let animationFrameId: number;
 
         const loop = () => {
+            let hasMoved = false;
+
             // 1. Head (index 0) eases toward mouse position
             const head = segs[0];
             const dxHead = mousePos.current.x - head.x;
             const dyHead = mousePos.current.y - head.y;
 
             let headAngle = head.angle;
-            if (Math.hypot(dxHead, dyHead) > 0.5) {
-                // Calculate rotation angle. Add 90 deg because default SVG faces UP
-                headAngle = Math.atan2(dyHead, dxHead) * (180 / Math.PI) + 90;
+            if (Math.hypot(dxHead, dyHead) > 0.1) {
+                hasMoved = true;
+                if (Math.hypot(dxHead, dyHead) > 0.5) {
+                    // Calculate rotation angle. Add 90 deg because default SVG faces UP
+                    headAngle = Math.atan2(dyHead, dxHead) * (180 / Math.PI) + 90;
+                }
             }
 
             head.x += dxHead * 0.25; // Easing speed
@@ -83,8 +88,11 @@ const RetroCursor = () => {
                 const dy = prev.y - current.y;
 
                 let angle = current.angle;
-                if (Math.hypot(dx, dy) > 0.5) {
-                    angle = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
+                if (Math.hypot(dx, dy) > 0.1) {
+                    hasMoved = true;
+                    if (Math.hypot(dx, dy) > 0.5) {
+                        angle = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
+                    }
                 }
 
                 // Smoothly pull segment toward the one in front of it
@@ -93,8 +101,12 @@ const RetroCursor = () => {
                 current.angle = angle;
             }
 
-            // Sync updated positions to component state
-            setTrail(segs.map(s => ({ ...s })));
+            // ⚡ Bolt: Prevent unnecessary React state updates (and ~60 re-renders/sec)
+            // when the mouse is idle by only calling setTrail if actual movement occurred.
+            if (hasMoved) {
+                // Sync updated positions to component state
+                setTrail(segs.map(s => ({ ...s })));
+            }
             animationFrameId = requestAnimationFrame(loop);
         };
 


### PR DESCRIPTION
💡 What: Prevented `setTrail` state updates when the mouse is idle in `src/components/RetroCursor.tsx` by wrapping it in a `hasMoved` conditional block.
🎯 Why: Calling a state setter inside `requestAnimationFrame` continuously, even without actual mouse movement, causes ~60 unnecessary React re-renders per second of complex SVG elements. This wastes CPU and battery on laptops.
📊 Impact: Eliminates idle re-renders, significantly reducing CPU usage and layout thrashing when the cursor is stationary.
🔬 Measurement: Can be verified by observing CPU/GPU usage via devtools performance tab or React DevTools Profiler, confirming no re-renders happen when the mouse is still.

---
*PR created automatically by Jules for task [13979140113440721435](https://jules.google.com/task/13979140113440721435) started by @SudoAnirudh*