### PR TITLE
🎨 Palette: Semantic Project Cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-07-23 - Semantic Buttons for Interactive Cards
+**Learning:** Using `div` elements with `onClick` for interactive cards prevents native keyboard focus and screen reader interaction. Nesting `<button>` elements inside other interactive elements causes accessibility issues.
+**Action:** Always use semantic `<button>` elements for clickable cards, provide appropriate `aria-label`s, handle `focus-visible` states, and ensure no interactive elements are nested inside them.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -54,10 +54,11 @@ const Projects = () => {
                         );
 
                         return (
-                            <div
+                            <button
                                 key={index}
-                                className="group cursor-pointer"
+                                className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                                 onClick={() => handleOpenProject(project, index)}
+                                aria-label={`Open project details for ${project.title}`}
                             >
                                 <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                     {isOngoing && (
@@ -90,12 +91,12 @@ const Projects = () => {
                                         {project.title.toLowerCase()}.exe
                                     </div>
                                     <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                        <span className="text-xs font-bold uppercase underline group-hover:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
💡 What: Replaced the generic `<div>` container for project cards in `Projects.tsx` with a semantic `<button>` element. Replaced the nested `<button>` element inside the card with a `<span>` to prevent HTML validation errors and accessibility issues. Added an `aria-label` to the new interactive card and configured proper focus-visible styles.

🎯 Why: Using `div` elements with `onClick` handlers for interactive cards prevents native keyboard focus and prevents screen readers from understanding that the element is interactive. Nesting `<button>` elements inside other interactive elements causes unpredictable screen reader behavior and breaks HTML standards. Using a semantic `<button>` for the card makes it inherently accessible via keyboard and screen readers.

📸 Before/After: Before, keyboard users could not tab to select project cards and screen readers did not announce them as buttons. After, users can navigate and trigger project cards using native keyboard focus, indicated clearly by a retro-yellow ring, and screen readers will announce them correctly.

♿ Accessibility: Native keyboard accessibility enabled (tab support) with visible focus states. Screen reader compatibility enabled via semantic `<button>` roles and descriptive `aria-label`s. Removed invalid nested interactive elements.

---
*PR created automatically by Jules for task [10435754641944907317](https://jules.google.com/task/10435754641944907317) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation and focus visibility for project cards.
  * Added descriptive labels for interactive project actions.
  * Updated project card interactions to use semantic controls.
  * Refined the “Load Cartridge” link styling to align with card hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->