### PR TITLE
🛡️ Sentinel: [security improvement] Enforce maxLength on contact form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+## 2026-07-24 - Enforce maxLength on client-side form inputs
+**Vulnerability:** Client-side form inputs lacking maxLength constraints can allow rudimentary application-layer DoS via oversized payloads, even if server-side validation exists.
+**Learning:** Client-side validation (`maxLength`) must explicitly align with server-side validation counterparts to prevent unnecessary processing of large payloads.
+**Prevention:** Always add `maxLength` attributes to `<input>` and `<textarea>` elements, matching the length constraints defined in the corresponding server actions.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./dist/types/routes.d.ts";
+import "./dist/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -271,6 +271,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className="w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400"
                                                 placeholder="ENTER NAME..."
+                                                maxLength={100}
                                                 type="text"
                                                 required
                                             />
@@ -284,6 +285,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className={`w-full bg-transparent border-b-2 border-black/20 p-3 font-body focus:outline-none focus:border-black transition-colors placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="ENTER EMAIL..."
+                                                maxLength={255}
                                                 type="email"
                                                 aria-invalid={!!emailError}
                                                 aria-describedby={emailError ? "email-error" : undefined}
@@ -300,6 +302,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className="w-full bg-zinc-50 border-2 border-black p-4 font-mono text-sm focus:outline-none focus:shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] transition-shadow resize-none h-40 sm:h-48"
                                                 placeholder="TYPE YOUR MESSAGE HERE..."
+                                                maxLength={5000}
                                                 required
                                             ></textarea>
                                         </div>


### PR DESCRIPTION
🛡️ **Sentinel Security Enhancement**

**Context:** Client-side form inputs lacking `maxLength` constraints can allow rudimentary application-layer DoS via oversized payloads, forcing the browser and server to process unnecessarily large strings, even if server-side validation eventually catches them.

**Enhancement:** This PR enforces explicit `maxLength` HTML attributes on the `Contact` form inputs (`Name: 100`, `Email: 255`, `Message: 5000`). These constraints precisely match the strict limits already defined in the corresponding server action (`src/app/actions/contact.ts`), ensuring a defense-in-depth approach against payload resource exhaustion.

---
*PR created automatically by Jules for task [3379446396534683979](https://jules.google.com/task/3379446396534683979) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added maximum character limits to contact form fields: 100 for names, 255 for email addresses, and 5,000 for messages.

* **Documentation**
  * Documented client-side input length requirements to support consistent validation and prevent oversized submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->