### PR TITLE
🎨 Palette: Fix accessibility on clickable project cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-07-24 - Accessible Clickable Project Cards
+**Learning:** Using `<div onClick={...}>` for interactive cards breaks keyboard navigation and screen reader support, and nesting `<button>` inside `<button>` is invalid HTML.
+**Action:** Use a single semantic `<button>` for the entire card with a visible focus ring, and convert any inner pseudo-buttons to styled `<span>` elements.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -54,10 +54,11 @@ const Projects = () => {
                         );
 
                         return (
-                            <div
+                            <button
                                 key={index}
-                                className="group cursor-pointer"
+                                className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                                 onClick={() => handleOpenProject(project, index)}
+                                aria-label={`View details for ${project.title}`}
                             >
                                 <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                     {isOngoing && (
@@ -89,13 +90,13 @@ const Projects = () => {
                                     <div className="text-xs font-body text-zinc-500 truncate px-2">
                                         {project.title.toLowerCase()}.exe
                                     </div>
-                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                    <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 transition-opacity">
+                                        <span className="text-xs font-bold uppercase underline group-hover:text-retro-orange group-focus-visible:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
💡 **What:** Refactored project cards from `<div onClick={...}>` to semantic `<button>` elements, converted inner nested `<button>`s to `<span>`s, and added descriptive ARIA labels with focus-visible states.

🎯 **Why:** To enable keyboard navigation, ensure proper screen reader support, and maintain valid HTML structure (preventing nested buttons).

📸 **Before/After:**
*(Before)* Project cards were divs, not focusable, unreadable context by screen readers, nested invalid button tags.
*(After)* Project cards are fully focusable semantic buttons with visible focus rings, readable ARIA context, and valid HTML structure.

♿ **Accessibility:**
- Changed cards to `<button>`
- Added `aria-label` based on project title
- Added `focus-visible:ring-2 focus-visible:ring-retro-yellow`
- Removed invalid nested `<button>` elements

---
*PR created automatically by Jules for task [449728920575413398](https://jules.google.com/task/449728920575413398) started by @SudoAnirudh*