### PR TITLE
⚡ Bolt: Throttle scroll event in Navbar

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-07-17 - [Cache DOM target in high-frequency event listeners]
 **Learning:** In high-frequency event listeners like `mousemove`, constantly re-evaluating expensive DOM traversals (e.g., `.closest()`) and recalculating styles (e.g., `getComputedStyle()`) on every pixel movement causes significant layout thrashing and CPU overhead.
 **Action:** Always cache the current DOM target (`e.target`) and only perform expensive checks when the target element actually changes.
+
+## 2026-07-25 - [Throttle High-Frequency Scroll State Updates]
+**Learning:** Attaching React state updates directly to high-frequency events like `scroll` without throttling causes excessive re-renders and degrades scrolling performance.
+**Action:** Always throttle scroll or resize event listeners using `requestAnimationFrame` to synchronize state updates with screen refreshes, and use `{ passive: true }` to avoid blocking the main thread's scrolling.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,14 +6,24 @@ const Navbar = () => {
     const [scrollProgress, setScrollProgress] = React.useState(0);
 
     React.useEffect(() => {
-        const handleScroll = () => {
-            const totalScroll = document.documentElement.scrollTop;
-            const windowHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-            const scroll = `${totalScroll / windowHeight}`;
-            setScrollProgress(Number(scroll));
-        }
+        let ticking = false;
 
-        window.addEventListener('scroll', handleScroll);
+        const handleScroll = () => {
+            if (!ticking) {
+                window.requestAnimationFrame(() => {
+                    const totalScroll = document.documentElement.scrollTop;
+                    const windowHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+                    // ⚡ Bolt: Prevent division by zero and unnecessary string conversions
+                    const scroll = windowHeight > 0 ? totalScroll / windowHeight : 0;
+                    setScrollProgress(scroll);
+                    ticking = false;
+                });
+                ticking = true;
+            }
+        };
+
+        // ⚡ Bolt: Add passive: true and throttle with requestAnimationFrame
+        window.addEventListener('scroll', handleScroll, { passive: true });
         return () => window.removeEventListener('scroll', handleScroll);
     }, []);
 


### PR DESCRIPTION
💡 What
Throttled the high-frequency `scroll` event listener in `src/components/Navbar.tsx` using `requestAnimationFrame`, and added the `{ passive: true }` flag to the event listener.

🎯 Why
The previous implementation updated React state (`scrollProgress`) on every single scroll event (dozens of times per second). This caused excessive re-renders of the `Navbar` component and layout thrashing, which degrades scrolling performance and battery life. Adding `{ passive: true }` signals to the browser that we won't call `preventDefault()`, allowing it to paint the scroll immediately without waiting for JS execution.

📊 Impact
- Reduces unnecessary React re-renders from dozens per second during scrolling to at most one per screen refresh (typically 60fps).
- Eliminates potential main-thread blocking during scroll interactions.
- Removes an inefficient string conversion (`Number(`${...}`)`).

🔬 Measurement
- Scroll down the page and observe the CPU profile using Chrome DevTools (Performance tab). The main thread should show significantly less JS execution time spent in React rendering cycles compared to the unoptimized version.
- Build and run successful using `pnpm build`.

---
*PR created automatically by Jules for task [4619309813938781772](https://jules.google.com/task/4619309813938781772) started by @SudoAnirudh*