### PR TITLE
🎨 Palette: Improve accessibility of project cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2024-07-25 - Fix Accessibility of Interactive Cards
+**Learning:** Using `div` for clickable cards and nesting `button` elements within them violates HTML semantics and causes accessibility/focus issues for screen readers and keyboard navigation.
+**Action:** Always use a single semantic `<button>` for interactive cards with proper `aria-label` and `focus-visible` styling, avoiding nested interactive elements.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -54,9 +54,10 @@ const Projects = () => {
                         );
 
                         return (
-                            <div
+                            <button
                                 key={index}
-                                className="group cursor-pointer"
+                                aria-label={`View details for project ${project.title}`}
+                                className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-retro-yellow focus-visible:ring-offset-2"
                                 onClick={() => handleOpenProject(project, index)}
                             >
                                 <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
@@ -90,12 +91,12 @@ const Projects = () => {
                                         {project.title.toLowerCase()}.exe
                                     </div>
                                     <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                        <span className="text-xs font-bold uppercase underline group-hover:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
**💡 What:**
Replaced the interactive `<div>` elements used for Project cards with semantic `<button>` tags, added descriptive `aria-label`s, replaced a nested `<button>` with a `<span>`, and applied `focus-visible` styling for a visible yellow outline when focused via keyboard navigation.

**🎯 Why:**
Using a `<div>` with an `onClick` handler violates HTML semantics. Screen readers cannot properly identify it as a button, and it inherently lacks keyboard navigability (via Tab). Additionally, HTML specification forbids nesting interactive elements (like a `<button>` inside another interactive element).

**📸 Before/After:**
*   *Before:* `<div>` cards could not be reached via `Tab`.
*   *After:* Users can `Tab` through each card naturally, with a clear retro-yellow `focus-visible` ring appearing on the active card.

**♿ Accessibility:**
*   **Semantic HTML:** Project cards are now proper `<button>` elements.
*   **Screen Readers:** Each card now has a descriptive `aria-label` (e.g., `"View details for project Pashuswasthya"`).
*   **Keyboard Navigation:** Fully supports `Tab` focusing and `Enter`/`Space` activation natively.
*   **Invalid HTML Fix:** Replaced nested `<button>` (Load Cartridge) with a styled `<span>` to prevent nested interactive elements.

---
*PR created automatically by Jules for task [15911843201103618894](https://jules.google.com/task/15911843201103618894) started by @SudoAnirudh*