### PR TITLE
🎨 Palette: Fix accessibility and semantic HTML in project cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2026-07-26 - Semantic Clickable Cards
+**Learning:** Using `<div onClick>` for interactive cards breaks native keyboard navigation (tab order) and screen reader support. Additionally, nesting buttons (like a 'Load Cartridge' button inside a clickable card) creates invalid HTML.
+**Action:** Always use semantic `<button>` tags for interactive components, apply `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color]` for focus states, and avoid nesting interactive elements.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -54,9 +54,10 @@ const Projects = () => {
                         );
 
                         return (
-                            <div
+                            <button
                                 key={index}
-                                className="group cursor-pointer"
+                                className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
+                                aria-label={`View details for ${project.title}`}
                                 onClick={() => handleOpenProject(project, index)}
                             >
                                 <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
@@ -90,12 +91,12 @@ const Projects = () => {
                                         {project.title.toLowerCase()}.exe
                                     </div>
                                     <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                        <span className="text-xs font-bold uppercase underline hover:text-retro-orange">
                                             Load Cartridge
-                                        </button>
+                                        </span>
                                     </div>
                                 </div>
-                            </div>
+                            </button>
                         );
                     })}
                 </div>


### PR DESCRIPTION
💡 What: Refactored the interactive project cards in `src/components/Projects.tsx` from clickable `<div>` elements into semantic `<button>` elements with `text-left block w-full` styling, and converted the nested `<button>` (Load Cartridge) into visually identical `<span>` tags. Added explicit `aria-label`s and `focus-visible:ring-2 focus-visible:ring-retro-yellow` states.

🎯 Why: The original implementation violated HTML semantics by wrapping interactive logic in generic divs and creating nested buttons. This prevented native keyboard focus (Tab navigation) and impaired screen reader accessibility.

📸 Before/After: Visual structure is preserved precisely (verified via Playwright rendering and screenshots in `verification3.png`). Focus states are now visible and native tab navigation is supported.

♿ Accessibility:
- Project cards are natively focusable and triggerable via Keyboard (Space/Enter).
- Prevented hydration and accessibility bugs caused by nested `<button>` elements.
- Implemented visible focus indicators (`focus-visible:ring-2`) for keyboard navigation.
- Added descriptive `aria-label` attributes to the cards for screen readers.

---
*PR created automatically by Jules for task [10049533871109157031](https://jules.google.com/task/10049533871109157031) started by @SudoAnirudh*