### PR TITLE
🎨 Palette: Improve keyboard accessibility for project cards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2026-07-28 - Semantic Accessible Cards
+**Learning:** Using semantic <button> instead of <div onClick> for clickable cards (like Project cards) is crucial for keyboard navigation and screen readers. Additionally, nesting interactive elements like <button> inside <button> creates invalid HTML and accessibility tree issues.
+**Action:** Always use semantic buttons with text-left w-full classes for interactive cards and convert nested interactive triggers to generic spans.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -104,15 +104,16 @@ const Projects = () => {
                             );
 
                             return (
-                                <motion.div
+                                <motion.button
                                     key={project.title}
                                     layout
                                     initial={{ opacity: 0, scale: 0.9 }}
                                     animate={{ opacity: 1, scale: 1 }}
                                     exit={{ opacity: 0, scale: 0.9 }}
                                     transition={{ duration: 0.25 }}
-                                    className="group cursor-pointer"
+                                    className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus-visible:ring-offset-2"
                                     onClick={() => handleOpenProject(project)}
+                                    aria-label={`View project details for ${project.title}`}
                                 >
                                     <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                         {isOngoing && (
@@ -145,12 +146,12 @@ const Projects = () => {
                                             {project.title.toLowerCase()}.exe
                                         </div>
                                         <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                            <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                            <span className="text-xs font-bold uppercase underline hover:text-retro-orange">
                                                 Load Cartridge
-                                            </button>
+                                            </span>
                                         </div>
                                     </div>
-                                </motion.div>
+                                </motion.button>
                             );
                         })}
                     </AnimatePresence>


### PR DESCRIPTION
**💡 What:**
Changed the clickable project cards in `Projects.tsx` from `motion.div` to `motion.button`. Added `aria-label` to the cards for screen readers, implemented `focus-visible` styles for clear keyboard navigation, and changed an invalid nested `<button>` (the "Load Cartridge" link) to a semantic `<span>`.

**🎯 Why:**
Clickable interactive elements should use native `<button>` tags (or anchors if navigating) rather than `<div>` with `onClick` handlers. This natively gives the element focusability and triggers on 'Enter' or 'Space'. Furthermore, nesting interactive elements (like a button inside another button) generates an invalid accessibility tree which creates severe usability issues for screen readers.

**📸 Before/After:**
- **Before:** Project cards were clickable `div`s without native keyboard focus, required mouse interaction to activate smoothly, and contained an invalid nested button.
- **After:** Project cards are now semantic buttons. Keyboard users navigating with `Tab` will see a clear `retro-yellow` outline, and screen readers will correctly identify them as buttons and read out the project title via `aria-label`.

**♿ Accessibility:**
- Resolved HTML validation error (nested buttons).
- Enabled native keyboard interaction (Tab, Enter/Space to activate).
- Added semantic `aria-label`s for screen readers.
- Added visual `focus-visible` focus ring for keyboard navigation without breaking mouse hover styling.

---
*PR created automatically by Jules for task [11246499872713232695](https://jules.google.com/task/11246499872713232695) started by @SudoAnirudh*