### PR TITLE
🎨 Palette: Semantic interactive cards for accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-07-29 - Semantic Interactive Cards
+**Learning:** Using `<div>` with `onClick` for cards loses native keyboard focus and screen reader context. Nesting `<button>` inside creates invalid HTML.
+**Action:** Always use semantic `<button>` elements for clickable cards with `text-left block w-full` and proper `focus-visible` styling, removing any nested interactive elements.

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -104,15 +104,16 @@ const Projects = () => {
                             );
 
                             return (
-                                <motion.div
+                                <motion.button
                                     key={project.title}
                                     layout
                                     initial={{ opacity: 0, scale: 0.9 }}
                                     animate={{ opacity: 1, scale: 1 }}
                                     exit={{ opacity: 0, scale: 0.9 }}
                                     transition={{ duration: 0.25 }}
-                                    className="group cursor-pointer"
+                                    className="group cursor-pointer text-left block w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                                     onClick={() => handleOpenProject(project)}
+                                    aria-label={`View details for ${project.title}`}
                                 >
                                     <div className="bg-zinc-100 border-2 border-black p-2 mb-2 group-hover:bg-retro-yellow transition-colors relative shadow-[4px_4px_0px_0px_rgba(0,0,0,1)] group-hover:translate-x-[2px] group-hover:translate-y-[2px] group-hover:shadow-[2px_2px_0px_0px_rgba(0,0,0,1)]">
                                         {isOngoing && (
@@ -145,12 +146,12 @@ const Projects = () => {
                                             {project.title.toLowerCase()}.exe
                                         </div>
                                         <div className="flex justify-center gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                                            <button className="text-xs font-bold uppercase underline hover:text-retro-orange">
+                                            <span className="text-xs font-bold uppercase underline hover:text-retro-orange">
                                                 Load Cartridge
-                                            </button>
+                                            </span>
                                         </div>
                                     </div>
-                                </motion.div>
+                                </motion.button>
                             );
                         })}
                     </AnimatePresence>


### PR DESCRIPTION
💡 **What**: Refactored the clickable project cards in `Projects.tsx` from `motion.div` elements to semantic `motion.button` elements. Added an `aria-label` to each card, explicitly implemented `focus-visible` outline styles, and changed the nested "Load Cartridge" `<button>` to a `<span>`.

🎯 **Why**: Using `<div>` elements with `onClick` handlers fails to provide native keyboard focus capabilities out-of-the-box and does not convey to screen readers that the element is an interactive control. By switching to a semantic `<button>`, we inherit native focus management and standard interaction behaviors. The nested button had to be changed because HTML specification forbids nesting interactive elements like a button within another button.

📸 **Before/After**:
*   *Before*: Keyboard users tabbing through the page would bypass the project cards entirely, or they wouldn't receive a focus ring. Screen readers would announce them as groups rather than buttons.
*   *After*: The cards are now fully integrated into the document's tab order, receive a clear yellow retro-themed focus ring when navigating via keyboard, and are announced as buttons with a descriptive "View details for [Project Title]" label by screen readers.

♿ **Accessibility**:
*   Fixed missing semantic role for interactive elements (changed `div` to `button`).
*   Fixed missing keyboard focus indicators (`focus-visible:ring-2 focus-visible:ring-retro-yellow`).
*   Fixed invalid nested interactive elements (`button` inside `button`).
*   Improved screen reader context via `aria-label`.

---
*PR created automatically by Jules for task [16159682750688376146](https://jules.google.com/task/16159682750688376146) started by @SudoAnirudh*