### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing client-side input length limits

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The application was missing a Content-Security-Policy (CSP) header, which is a critical defense-in-depth mechanism against Cross-Site Scripting (XSS). Additionally, a programmatic call to `window.open` in `src/components/ReceiptPrinter.tsx` lacked the `"noopener,noreferrer"` parameters, making it susceptible to reverse tabnabbing (where the opened window can manipulate the `window.opener` object).
 **Learning:** Next.js global headers should always include a CSP configuration. While static HTML links might often have `target="_blank" rel="noopener noreferrer"`, it is easy to overlook these protections in programmatic JavaScript API calls like `window.open`.
 **Prevention:** Always verify that `window.open(..., '_blank')` calls include `"noopener,noreferrer"` as the third argument. Ensure standard security headers, specifically CSP, are explicitly defined in Next.js configuration or middleware.
+
+## 2026-07-30 - Client-side Input Length Limits
+**Vulnerability:** Missing client-side length limits on form inputs could allow rudimentary application-layer DoS via oversized payloads.
+**Learning:** Client-side inputs must enforce `maxLength` attributes to explicitly align with server-side limits (e.g., Name: 100, Email: 255, Message: 5000).
+**Prevention:** Always add `maxLength` constraints to text inputs and textareas to prevent resource exhaustion.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -539,6 +539,7 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
+                                            {/* SECURITY: Enforce maxLength to prevent rudimentary application-layer DoS via oversized payloads */}
                                             <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
                                             <input
                                                 id="name"
@@ -549,10 +550,12 @@ const Contact = () => {
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400"
                                                 placeholder="e.g. Sarah Jenkins"
                                                 type="text"
+                                                maxLength={100}
                                                 required
                                             />
                                         </div>
                                         <div>
+                                            {/* SECURITY: Enforce maxLength to prevent rudimentary application-layer DoS via oversized payloads */}
                                             <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
                                             <input
                                                 id="email"
@@ -562,6 +565,7 @@ const Contact = () => {
                                                 className={`w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="e.g. sarah@company.com"
                                                 type="email"
+                                                maxLength={255}
                                                 aria-invalid={!!emailError}
                                                 aria-describedby={emailError ? "email-error" : undefined}
                                                 required
@@ -599,6 +603,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
+                                            {/* SECURITY: Enforce maxLength to prevent rudimentary application-layer DoS via oversized payloads */}
                                             <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
                                             <textarea
                                                 id="message"
@@ -607,6 +612,7 @@ const Contact = () => {
                                                 onChange={handleChange}
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3.5 font-body text-sm text-zinc-900 focus:outline-none focus:border-black focus:bg-white transition-all resize-none h-36"
                                                 placeholder="Write your message..."
+                                                maxLength={5000}
                                                 required
                                             ></textarea>
                                         </div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing client-side length limits on form inputs could allow rudimentary application-layer DoS via oversized payloads.
🎯 Impact: Attackers could submit extremely large strings in the contact form, leading to excessive resource consumption on the server and potential service degradation.
🔧 Fix: Enforced `maxLength` attributes on the `name`, `email`, and `message` inputs in `src/components/Contact.tsx` to explicitly align with their server-side validation counterparts (100, 255, and 5000 characters respectively). Added security-related code comments adjacent to the fixes.
✅ Verification: Verified locally by running `pnpm lint` and `pnpm build`. Added a journal entry to `.jules/sentinel.md` documenting the learning.

---
*PR created automatically by Jules for task [480633376205590215](https://jules.google.com/task/480633376205590215) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added client-side length limits to contact form fields.
  * Prevents excessively long names, email addresses, and messages from being submitted.
* **Documentation**
  * Added guidance documenting input length constraints and alignment with server-side limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->