### PR TITLE
⚡ Bolt: [performance improvement] Throttle scroll event listener in Navbar

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,6 @@
 ## 2026-07-17 - [Cache DOM target in high-frequency event listeners]
 **Learning:** In high-frequency event listeners like `mousemove`, constantly re-evaluating expensive DOM traversals (e.g., `.closest()`) and recalculating styles (e.g., `getComputedStyle()`) on every pixel movement causes significant layout thrashing and CPU overhead.
 **Action:** Always cache the current DOM target (`e.target`) and only perform expensive checks when the target element actually changes.
+## 2026-07-30 - [Throttled Scroll Listeners]
+**Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
+**Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,15 +6,29 @@ const Navbar = () => {
     const [scrollProgress, setScrollProgress] = React.useState(0);
 
     React.useEffect(() => {
+        let ticking = false;
+        let animationFrameId: number | null = null;
         const handleScroll = () => {
-            const totalScroll = document.documentElement.scrollTop;
-            const windowHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
-            const scroll = `${totalScroll / windowHeight}`;
-            setScrollProgress(Number(scroll));
+            if (!ticking) {
+                animationFrameId = window.requestAnimationFrame(() => {
+                    const totalScroll = document.documentElement.scrollTop;
+                    const windowHeight = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+                    const scroll = `${totalScroll / windowHeight}`;
+                    setScrollProgress(Number(scroll));
+                    ticking = false;
+                });
+                ticking = true;
+            }
         }
 
-        window.addEventListener('scroll', handleScroll);
-        return () => window.removeEventListener('scroll', handleScroll);
+        // PERFORMANCE: Throttled scroll listener using requestAnimationFrame and { passive: true } to prevent main thread blocking during high-frequency events.
+        window.addEventListener('scroll', handleScroll, { passive: true });
+        return () => {
+            window.removeEventListener('scroll', handleScroll);
+            if (animationFrameId !== null) {
+                window.cancelAnimationFrame(animationFrameId);
+            }
+        };
     }, []);
 
     return (


### PR DESCRIPTION
💡 What:
Throttled the `scroll` event listener in `src/components/Navbar.tsx` by using `requestAnimationFrame` to limit the frequency of React state updates, and marked the event listener with `{ passive: true }`. A cleanup function was also implemented to correctly cancel any pending animation frames using `cancelAnimationFrame` when the component unmounts.

🎯 Why:
High-frequency event listeners like `scroll` can cause significant main thread blocking and layout thrashing, especially when they trigger React state updates (e.g., updating the scroll progress bar in the `Navbar`). Throttling these updates aligns them with the display's refresh rate (via `requestAnimationFrame`), mitigating jank and performance degradation. Using `{ passive: true }` explicitly informs the browser that the event listener will not call `preventDefault()`, which helps keep scrolling smooth.

📊 Impact:
Significantly reduces the number of times `setScrollProgress` is called during rapid scrolling events. This decreases the overall rendering overhead and ensures that scroll performance is consistently smooth without main thread blockage or jank.

🔬 Measurement:
- Start the development server (`pnpm dev`).
- Open the application and perform rapid scrolling up and down the page.
- Using Chrome DevTools' Performance tab, observe the reduction in time spent in JS execution and React commit phases during scrolling compared to before. Main thread blocking should be visibly reduced, and the scroll progress bar should update seamlessly.

---
*PR created automatically by Jules for task [18318727984834451601](https://jules.google.com/task/18318727984834451601) started by @SudoAnirudh*