### PR TITLE
🎨 Palette: Add aria-label and focus states to project modal close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-07-31 - Missing ARIA Labels on Custom Window Headers
+**Learning:** Custom UI components resembling retro OS windows often rely on icon-only close buttons (like the `close` symbol) in their headers, which lack accessible names and keyboard focus indicators, making them invisible to screen readers and difficult to navigate via keyboard.
+**Action:** Always verify that icon-only interactive controls (like minimize, maximize, and close) in custom window headers explicitly provide descriptive `aria-label` attributes and visible focus states (`focus-visible:ring-2`).

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -2553,9 +2553,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                     </div>
                     <button
                         onClick={onClose}
-                        className="hover:bg-red-500 p-1 rounded-none transition-colors"
+                        aria-label="Close project modal"
+                        className="hover:bg-red-500 p-1 rounded-none transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow"
                     >
-                        <span className="material-symbols-outlined text-sm block">close</span>
+                        <span className="material-symbols-outlined text-sm block" aria-hidden="true">close</span>
                     </button>
                 </div>
 


### PR DESCRIPTION
💡 **What**: Added an `aria-label` to the icon-only close button in `ProjectModal.tsx`, applied `aria-hidden="true"` to the inner icon span, and added visible focus styles (`focus-visible:ring-2 focus-visible:ring-retro-yellow`). Also documented this pattern in `.jules/palette.md`.
🎯 **Why**: To make the close button accessible to screen readers (preventing it from announcing the literal word "close" due to the material symbols font) and to ensure keyboard users can clearly see when the button is focused.
📸 **Before/After**: Visually, there is no change until the button receives keyboard focus, at which point a yellow ring appears around it.
♿ **Accessibility**: Significant improvement for screen reader and keyboard navigation users interacting with the retro custom window components.

---
*PR created automatically by Jules for task [10982731712619882781](https://jules.google.com/task/10982731712619882781) started by @SudoAnirudh*