### PR TITLE
🎨 Palette: Improve contact form accessibility with required indicators and focus rings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -28,3 +28,7 @@
 ## 2024-05-18 - Form and Social Links Accessibility Improvements
 **Learning:** In the `Contact.tsx` component, form inputs were relying solely on placeholders without `<label>` elements, which breaks screen reader support. Social icons were missing `aria-label`s, and text inside `span` with `material-symbols-outlined` was being read by screen readers.
 **Action:** Always provide `<label>` elements (using `sr-only` class if they should be visually hidden) for inputs, associate error states using `aria-invalid` and `aria-describedby`, add `aria-label` to icon-only links, and use `aria-hidden="true"` on the internal icon elements to prevent redundant reading. Also ensure external links include `target="_blank" rel="noopener noreferrer"` for security.
+
+## $(date +%Y-%m-%d) - Required Indicator Accessibility Pattern
+**Learning:** While form fields had the `required` attribute and were validated by the browser, they lacked visual indications of being required.
+**Action:** Standardize adding a visual required indicator by appending `<span className="text-red-500 ml-1" aria-hidden="true">*</span>` directly inside the corresponding `<label>` element for all required fields to improve user understanding without disrupting screen readers.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -539,27 +539,27 @@ const Contact = () => {
                                 <div className="bg-retro-white p-5 sm:p-8 relative overflow-hidden flex flex-col justify-center min-h-[420px] sm:min-h-[500px]">
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
                                                 name="name"
                                                 value={formData.name}
                                                 onChange={handleChange}
-                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400"
+                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400"
                                                 placeholder="e.g. Sarah Jenkins"
                                                 type="text"
                                                 required
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
                                                 value={formData.email}
                                                 onChange={handleChange}
-                                                className={`w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
+                                                className={`w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 ${emailError ? 'border-red-500' : ''}`}
                                                 placeholder="e.g. sarah@company.com"
                                                 type="email"
                                                 aria-invalid={!!emailError}
@@ -593,19 +593,19 @@ const Contact = () => {
                                                 name="subject"
                                                 value={formData.subject}
                                                 onChange={handleChange}
-                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
+                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
                                                 placeholder="Subject details..."
                                                 type="text"
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"
                                                 value={formData.message}
                                                 onChange={handleChange}
-                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3.5 font-body text-sm text-zinc-900 focus:outline-none focus:border-black focus:bg-white transition-all resize-none h-36"
+                                                className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3.5 font-body text-sm text-zinc-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow focus:border-black focus:bg-white transition-all resize-none h-36"
                                                 placeholder="Write your message..."
                                                 required
                                             ></textarea>


### PR DESCRIPTION
💡 What
Added visual required indicators (`*`) to the Name, Email, and Message labels on the Contact form, and replaced generic `focus:outline-none` with accessible keyboard focus rings (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-retro-yellow`).

🎯 Why
Users were unable to visually distinguish which fields were required before attempting submission. Additionally, the lack of a proper focus ring made keyboard navigation extremely difficult for users navigating the form via the `Tab` key.

📸 Before/After
(Visually verified locally with screenshots and videos of keyboard navigation).
Before: Required fields had no visual indicator, and tabbing through the form provided no clear focus state.
After: Required fields have a red asterisk, and keyboard navigation produces a clear, thick retro-yellow outline around the active input.

♿ Accessibility
*   Added `aria-hidden="true"` to the required asterisk span so screen readers do not read "star" out loud redundantly, as they already announce the `required` state based on the input's attribute.
*   Implemented `focus-visible` styling to ensure focus rings only appear for keyboard navigation and do not disrupt mouse interactions.

---
*PR created automatically by Jules for task [11322274024064883643](https://jules.google.com/task/11322274024064883643) started by @SudoAnirudh*