### PR TITLE
⚡ Bolt: [performance improvement] Add passive flag to mousemove listeners

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2026-08-02 - [Passive Mousemove Listeners]
+**Learning:** High-frequency event listeners like `mousemove` can cause significant main thread blocking and jank if not properly managed, similar to `scroll` or `resize`.
+**Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.

--- a/src/components/RetroCursor.tsx
+++ b/src/components/RetroCursor.tsx
@@ -231,7 +231,8 @@ const RetroCursor = () => {
             animationFrameId = requestAnimationFrame(loop);
         };
 
-        window.addEventListener('mousemove', updateMousePos);
+        // PERFORMANCE: Added { passive: true } to high-frequency mousemove event listener to prevent main thread blocking
+        window.addEventListener('mousemove', updateMousePos, { passive: true });
         window.addEventListener('mousedown', handleMouseDown);
         window.addEventListener('mouseup', handleMouseUp);
 

--- a/src/components/RetroLoader.tsx
+++ b/src/components/RetroLoader.tsx
@@ -96,7 +96,8 @@ const RetroLoader = () => {
             setMousePos({ x, y });
         };
 
-        window.addEventListener('mousemove', handleMouseMove);
+        // PERFORMANCE: Added { passive: true } to high-frequency mousemove event listener to prevent main thread blocking
+        window.addEventListener('mousemove', handleMouseMove, { passive: true });
 
         // Timing flow:
         // Step 1 (Blinking Floppy Disk): 0s - 0.8s


### PR DESCRIPTION
💡 What
Added the `{ passive: true }` flag to high-frequency `mousemove` event listeners in `RetroCursor.tsx` and `RetroLoader.tsx`. 

🎯 Why
High-frequency events can cause the browser main thread to block because the browser has to wait to see if the event listener will call `e.preventDefault()`. By explicitly marking the listener as `passive`, the browser knows it can proceed with optimizations without waiting. Although this is most critical for scroll-blocking events (like `touchmove` and `wheel`), it is a safe and harmless best practice to apply to high-frequency `mousemove` events that trigger internal state or DOM updates.

📊 Impact
Prevents potential main thread blocking and reduces jank during rapid mouse movements on the site, resulting in smoother animations for the retro cursor and the bootup loader.

🔬 Measurement
Review the changes in `src/components/RetroCursor.tsx` and `src/components/RetroLoader.tsx` to confirm the `{ passive: true }` option was added to the `window.addEventListener('mousemove', ...)` calls.

---
*PR created automatically by Jules for task [16581876656271847496](https://jules.google.com/task/16581876656271847496) started by @SudoAnirudh*