### PR TITLE
🎨 Palette: [UX improvement] Add explicit required indicators to Contact form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## $(date +%Y-%m-%d) - Adding Required Indicators to Form Fields
+**Learning:** For Next.js development within this workspace, modifying a file and subsequently running `pnpm build` will often cause auto-generated changes to `next-env.d.ts`. Committing this generated file creates unnecessary version control noise and shouldn't be included in UX PRs.
+**Action:** Always ensure that after running build or test commands locally during verification, the `next-env.d.ts` file modifications are discarded using `git restore --staged next-env.d.ts && git checkout next-env.d.ts` before creating the final PR to maintain a clean git history.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -540,7 +540,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -555,7 +555,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -602,7 +602,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
💡 What: Added explicit red asterisk (`*`) indicators to the `Your Name`, `Your Email`, and `Your Message` input labels in the Contact form to signify they are required.

🎯 Why: Users need immediate visual cues to know which fields are mandatory before attempting to submit a form. This prevents frustration and submission errors.

📸 Before/After: Before, labels were just text. Now, required fields have a red asterisk next to the label.

♿ Accessibility: The asterisk includes `aria-hidden="true"` so screen readers don't read out "star", relying instead on the inputs' native `required` attribute.

---
*PR created automatically by Jules for task [7395534891668840140](https://jules.google.com/task/7395534891668840140) started by @SudoAnirudh*