### PR TITLE
🎨 Palette: [UX improvement] Add visual indicators for required form fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+
+## 2026-08-03 - Add Visual Indicators to Required Form Fields
+**Learning:** When form fields use the `required` attribute, users and screen readers benefit from an explicit visual indicator appended directly inside the corresponding `<label>` element to communicate the requirement effectively.
+**Action:** Always append `<span className="text-red-500 ml-1" aria-hidden="true">*</span>` inside the `<label>` for any required input field.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -540,7 +540,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -555,7 +555,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -602,7 +602,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
### 💡 What
Added a visible red asterisk (`*`) to the `<label>` elements for all required fields ("Your Name", "Your Email", and "Your Message") in the `Contact.tsx` form.

### 🎯 Why
When form fields use the HTML `required` attribute, users benefit from an explicit visual indicator. Without it, users may only discover a field is required after attempting to submit the form and encountering a validation error. Adding a visual indicator proactively communicates the requirement, leading to a smoother and more intuitive user experience.

### 📸 Before/After
*   **Before:** Labels displayed simply as "Your Name", "Your Email", and "Your Message".
*   **After:** Labels now display as "Your Name*", "Your Email*", and "Your Message*".

### ♿ Accessibility
The newly added visual indicator explicitly includes `aria-hidden="true"`. Because the input fields themselves already have the `required` HTML attribute, screen readers will natively announce them as required. Hiding the visual asterisk from screen readers prevents redundant or confusing announcements like "Your Name star required".

---
*PR created automatically by Jules for task [8589750195505045786](https://jules.google.com/task/8589750195505045786) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added visual required-field indicators to the contact form’s name, email, and message labels.
  * Indicators are hidden from screen readers to avoid redundant announcements.
* **Documentation**
  * Documented the required-label indicator convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->