### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
### 💡 What
Added a visible red asterisk (`*`) next to the labels for all required fields in the Contact form ("Your Name", "Your Email", and "Your Message"). 

### 🎯 Why
While the input elements themselves had the native HTML5 `required` attribute, there was no visual indicator on the screen to inform sighted users that these fields were mandatory before they attempted to submit the form. This addition makes the user interface more intuitive and prevents validation frustration.

### 📸 Before/After
See the generated verification screenshot. The labels now appear as: 
- `Your Name*` 
- `Your Email*`
- `Your Message*`

### ♿ Accessibility
The asterisk explicitly has `aria-hidden="true"` applied to it (e.g. `<span className="..." aria-hidden="true">*</span>`). This prevents screen readers from announcing "star" redundantly, since screen readers will already announce that the field is "required" due to the native `required` attribute on the corresponding `<input>`/`<textarea>`.

---
*PR created automatically by Jules for task [9809501133443857395](https://jules.google.com/task/9809501133443857395) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added red asterisk indicators to identify required name, email, and message fields in the contact form.
  * Indicators are hidden from assistive technologies to preserve accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->