### PR TITLE
🛡️ Sentinel: [security improvement]

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** Missing client-side length validation on contact form inputs.
 **Learning:** Client-side inputs lacked maxLength attributes corresponding to server-side constraints in actions/contact.ts, which could allow rudimentary application-layer DoS via oversized payloads.
 **Prevention:** Always ensure client-side form inputs enforce maxLength attributes explicitly aligned with their server-side validation counterparts.
+## 2026-08-04 - [Missing Length Limits on Optional Fields]
+**Vulnerability:** The optional 'subject' field in the contact form lacked both client-side and server-side length limits, presenting a potential application-layer DoS vector via oversized payloads.
+**Learning:** Optional fields are just as susceptible to abusive input as required ones and often get overlooked during validation enforcement.
+**Prevention:** Apply consistent input validation, including explicit max lengths (e.g., maxLength=200 for short text), uniformly across all form inputs, regardless of whether they are required or optional.

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -39,6 +39,11 @@ export async function submitContactForm(formData: { name: string; email: string;
         return { success: false, error: 'Message must be between 10 and 5000 characters.' };
     }
 
+    // SECURITY: Enforce max length on the subject field to prevent DoS via oversized payloads.
+    if (subject.length > 200) {
+        return { success: false, error: 'Subject cannot exceed 200 characters.' };
+    }
+
     const safeName = escapeHTML(name);
     const safeEmail = escapeHTML(email);
     const safeMessage = escapeHTML(message);

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -599,6 +599,7 @@ const Contact = () => {
                                                     </button>
                                                 ))}
                                             </div>
+                                            {/* SECURITY: Enforce maxLength on optional fields to prevent DoS via oversized payloads */}
                                             <input
                                                 id="subject"
                                                 name="subject"
@@ -607,6 +608,7 @@ const Contact = () => {
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
                                                 placeholder="Subject details..."
                                                 type="text"
+                                                maxLength={200}
                                             />
                                         </div>
                                         <div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The optional 'subject' field in the contact form lacked both client-side and server-side length limits, presenting a potential application-layer DoS vector via oversized payloads.
🎯 Impact: Attackers could send extremely large string payloads to the contact endpoint, consuming server resources unnecessarily.
🔧 Fix: Added explicit client-side `maxLength={200}` to the subject input field and server-side length validation to ensure the subject length cannot exceed 200 characters.
✅ Verification: Tested visually via playwright confirming client-side limits are respected, and ran `pnpm build` & `pnpm lint` to ensure no build regressions.

---
*PR created automatically by Jules for task [3904146504760563092](https://jules.google.com/task/3904146504760563092) started by @SudoAnirudh*