### PR TITLE
⚡ Bolt: [performance improvement] Throttle React state updates in RetroLoader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+## 2026-08-04 - Throttling React state updates in high-frequency events
+**Learning:** Unthrottled React state updates in `mousemove` listeners cause significant overhead and layout thrashing.
+**Action:** Always throttle high-frequency React state updates using `requestAnimationFrame` when syncing mouse position to state, and remember to clear it with `cancelAnimationFrame` on unmount.

--- a/src/components/RetroLoader.tsx
+++ b/src/components/RetroLoader.tsx
@@ -88,15 +88,22 @@ const RetroLoader = () => {
         setShowLoader(true);
         document.body.classList.add('overflow-hidden');
 
+        let animationFrameId: number | null = null;
         const handleMouseMove = (e: MouseEvent) => {
-            const { innerWidth, innerHeight } = window;
-            // Calculate mouse position relative to center of screen, bounded between -1 and 1
-            const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
-            const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
-            setMousePos({ x, y });
+            if (animationFrameId === null) {
+                // PERFORMANCE: Throttle React state update in mousemove listener using requestAnimationFrame to prevent layout thrashing and main thread blocking.
+                animationFrameId = requestAnimationFrame(() => {
+                    const { innerWidth, innerHeight } = window;
+                    // Calculate mouse position relative to center of screen, bounded between -1 and 1
+                    const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
+                    const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
+                    setMousePos({ x, y });
+                    animationFrameId = null;
+                });
+            }
         };
 
-        window.addEventListener('mousemove', handleMouseMove);
+        window.addEventListener('mousemove', handleMouseMove, { passive: true });
 
         // Timing flow:
         // Step 1 (Blinking Floppy Disk): 0s - 0.8s
@@ -141,6 +148,7 @@ const RetroLoader = () => {
             clearTimeout(t4);
             clearTimeout(t5);
             window.removeEventListener('mousemove', handleMouseMove);
+            if (animationFrameId !== null) cancelAnimationFrame(animationFrameId);
             document.body.classList.remove('overflow-hidden');
         };
     }, []);


### PR DESCRIPTION
💡 What: Wrapped the `setMousePos` React state update within the `mousemove` listener in `src/components/RetroLoader.tsx` with `requestAnimationFrame`, storing the frame ID to allow for cleanup with `cancelAnimationFrame` on unmount.

🎯 Why: High-frequency `mousemove` events were directly triggering React state updates on every pixel movement, which caused layout thrashing and unnecessary CPU overhead on the main thread during the boot animation sequence.

📊 Impact: Reduces rapid cascading state updates and main thread blocking, matching the browser's 60FPS refresh rate and resulting in smoother boot sequence animations and lower CPU usage.

🔬 Measurement: Verify locally by starting the dev server and observing the 3D tilt animation of the boot sequence (the floppy disk, Happy Mac, progress bar, etc). The animation will maintain smoother framerates when moving the mouse quickly across the screen.

---
*PR created automatically by Jules for task [14163485791940211093](https://jules.google.com/task/14163485791940211093) started by @SudoAnirudh*