### PR TITLE
⚡ Bolt: [performance improvement] Optimize mouse movement state updates in RetroLoader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,6 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+## 2026-08-05 - Throttling React state updates on mouse move
+**Learning:** High-frequency event listeners like `mousemove` that trigger React state updates can cause layout thrashing and main thread blocking.
+**Action:** Throttle the state updates using `requestAnimationFrame` to synchronize with screen refreshes and cancel the animation frame on unmount.

--- a/src/components/RetroLoader.tsx
+++ b/src/components/RetroLoader.tsx
@@ -88,12 +88,20 @@ const RetroLoader = () => {
         setShowLoader(true);
         document.body.classList.add('overflow-hidden');
 
+        let animationFrameId: number;
+
         const handleMouseMove = (e: MouseEvent) => {
-            const { innerWidth, innerHeight } = window;
-            // Calculate mouse position relative to center of screen, bounded between -1 and 1
-            const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
-            const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
-            setMousePos({ x, y });
+            // OPTIMIZATION: Throttle React state updates using requestAnimationFrame to synchronize
+            // with screen refreshes and prevent main thread blocking during rapid mouse movements.
+            if (animationFrameId) cancelAnimationFrame(animationFrameId);
+
+            animationFrameId = requestAnimationFrame(() => {
+                const { innerWidth, innerHeight } = window;
+                // Calculate mouse position relative to center of screen, bounded between -1 and 1
+                const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
+                const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
+                setMousePos({ x, y });
+            });
         };
 
         window.addEventListener('mousemove', handleMouseMove);
@@ -141,6 +149,7 @@ const RetroLoader = () => {
             clearTimeout(t4);
             clearTimeout(t5);
             window.removeEventListener('mousemove', handleMouseMove);
+            if (animationFrameId) cancelAnimationFrame(animationFrameId);
             document.body.classList.remove('overflow-hidden');
         };
     }, []);


### PR DESCRIPTION
💡 **What**: Throttled `setMousePos` React state updates in the `mousemove` event listener of `RetroLoader.tsx` using `requestAnimationFrame`. Added `cancelAnimationFrame` in the cleanup function.
🎯 **Why**: High-frequency event listeners like `mousemove` that trigger synchronous React state updates cause layout thrashing and main thread blocking, hurting performance. Throttling them synchronizes updates with screen refreshes.
📊 **Impact**: Prevents main thread blocking and reduces unnecessary re-renders during the boot loading sequence.
🔬 **Measurement**: Verified visually through local testing using Playwright script that mouse interaction and 3D tilt effects remain smooth. No regressions introduced.

---
*PR created automatically by Jules for task [10033424088913763054](https://jules.google.com/task/10033424088913763054) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved the loader’s response to mouse movement for smoother, more consistent tilt effects.

* **Bug Fixes**
  * Prevented unnecessary visual updates during rapid cursor movement.
  * Improved cleanup when leaving the loader, reducing the chance of lingering motion effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->