### PR TITLE
🎨 Palette: [UX improvement] Add required field indicators to Contact form

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-07-07 - Add ARIA Labels to Custom OS Components
 **Learning:** Icon-only interactive controls and text-based icon fonts (like material-symbols-outlined) in custom retro UI components must explicitly implement `aria-label` and `aria-hidden='true'` to prevent screen readers from reading literal icon text, and custom form inputs must be linked to labels via `id`/`htmlFor`.
 **Action:** Always add descriptive `aria-label` to icon buttons, apply `aria-hidden='true'` to their internal text-based icon spans, and associate form inputs correctly.
+## 2026-08-05 - [Required Field Indicators]
+**Learning:** When form fields use the `required` attribute, explicitly define a visual indicator by appending `<span className="text-red-500 ml-1" aria-hidden="true">*</span>` directly inside the corresponding `<label>` element to enhance usability without compromising accessibility.
+**Action:** Always verify if a visual indicator is present for required inputs, and ensure it uses `aria-hidden="true"` to prevent screen reader redundancy.

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
### 💡 What
Added a visible red asterisk (`*`) to the form field labels for "Your Name", "Your Email", and "Your Message" in the Contact form to clearly indicate that these fields are mandatory.

### 🎯 Why
The form fields used the HTML `required` attribute, but there was no explicit visual indication to the user that they were mandatory. This small UX improvement helps set clear expectations before users begin filling out or attempting to submit the form.

### 📸 Before/After
**Before:** Labels appeared as plain text (e.g., "YOUR NAME").
**After:** Labels now include a red asterisk (e.g., "YOUR NAME *"). 

### ♿ Accessibility
The newly added visual indicator is accompanied by `aria-hidden="true"`, ensuring that screen readers do not redundantly announce "star" alongside the native `required` attribute, preventing user confusion while maintaining strict accessibility standards.

---
*PR created automatically by Jules for task [17247920105104668179](https://jules.google.com/task/17247920105104668179) started by @SudoAnirudh*