### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
**💡 What**: Added a visual `*` indicator to the "Name", "Email", and "Message" fields in the contact form.
**🎯 Why**: To explicitly denote required fields, enhancing form usability and reducing user friction during submission.
**📸 Before/After**: (Verified visually via Playwright - screenshots and videos recorded locally).
**♿ Accessibility**: Applied `aria-hidden="true"` to the asterisk to prevent screen readers from redundantly announcing "star" in addition to the label text, ensuring a smooth auditory experience.

---
*PR created automatically by Jules for task [1627669306322239765](https://jules.google.com/task/1627669306322239765) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added required-field indicators to the contact form’s name, email, and message labels.
  * No changes were made to form validation or submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->