### PR TITLE
⚡ Bolt: [performance improvement] Throttle RetroLoader mousemove state sync

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2026-08-06 - [Throttle MouseMove State Updates with rAF]
+**Learning:** Syncing `mousemove` event coordinates directly to React state (e.g., via `setMousePos`) on every event emission causes significant layout thrashing and blocks the main thread with excessive re-renders.
+**Action:** Always wrap the state update in `requestAnimationFrame` to synchronize with screen refreshes, and ensure `cancelAnimationFrame` is called in the `useEffect` cleanup function to prevent memory leaks on unmount.

--- a/src/components/RetroLoader.tsx
+++ b/src/components/RetroLoader.tsx
@@ -88,14 +88,22 @@ const RetroLoader = () => {
         setShowLoader(true);
         document.body.classList.add('overflow-hidden');
 
+        let animationFrameId: number | null = null;
         const handleMouseMove = (e: MouseEvent) => {
-            const { innerWidth, innerHeight } = window;
-            // Calculate mouse position relative to center of screen, bounded between -1 and 1
-            const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
-            const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
-            setMousePos({ x, y });
+            if (animationFrameId !== null) {
+                window.cancelAnimationFrame(animationFrameId);
+            }
+            animationFrameId = window.requestAnimationFrame(() => {
+                const { innerWidth, innerHeight } = window;
+                // Calculate mouse position relative to center of screen, bounded between -1 and 1
+                const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
+                const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
+                setMousePos({ x, y });
+                animationFrameId = null;
+            });
         };
 
+        // PERFORMANCE: Wrap state update in requestAnimationFrame to prevent layout thrashing and main thread blocking
         window.addEventListener('mousemove', handleMouseMove);
 
         // Timing flow:
@@ -141,6 +149,9 @@ const RetroLoader = () => {
             clearTimeout(t4);
             clearTimeout(t5);
             window.removeEventListener('mousemove', handleMouseMove);
+            if (animationFrameId !== null) {
+                window.cancelAnimationFrame(animationFrameId);
+            }
             document.body.classList.remove('overflow-hidden');
         };
     }, []);


### PR DESCRIPTION
💡 **What:** Throttled the `mousemove` state sync in `RetroLoader.tsx` using `requestAnimationFrame`.
🎯 **Why:** Unthrottled mouse event handling directly driving React state updates (`setMousePos`) caused excessive main-thread blocking and layout thrashing since `mousemove` events can fire significantly faster than the display refresh rate.
📊 **Impact:** Reduces main-thread blocking time during the initial boot animation by aligning React state updates and subsequent re-renders with the browser's native paint cycle, smoothing out the 3D tilt animation of the loader elements.
🔬 **Measurement:** Verify the boot animation remains visually smooth when aggressively moving the mouse. Performance profiling will show a significant reduction in React update calls and layout recalculations compared to unthrottled state setting.

---
*PR created automatically by Jules for task [15107693847518335443](https://jules.google.com/task/15107693847518335443) started by @SudoAnirudh*