### PR TITLE
⚡ Bolt: [performance improvement] Throttle mousemove event state updates in RetroCursor

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2026-08-07 - [Throttled High-Frequency Event State Updates]
+**Learning:** In high-frequency event listeners like `mousemove`, directly updating React state (e.g., `setStaticPos` in `RetroCursor.tsx`) on every event invocation causes excessive re-renders, layout thrashing, and main thread blocking.
+**Action:** Always wrap state updates in `requestAnimationFrame` for continuous high-frequency events to synchronize with the browser's refresh rate. Ensure the animation frame is cancelled in the cleanup function.

--- a/src/components/RetroCursor.tsx
+++ b/src/components/RetroCursor.tsx
@@ -89,13 +89,20 @@ const RetroCursor = () => {
         }));
 
         let lastTarget: EventTarget | null = null;
+        let staticPosRafId: number | null = null;
 
         const updateMousePos = (e: MouseEvent) => {
             mousePos.current = { x: e.clientX, y: e.clientY };
             lastMoveTime.current = Date.now();
 
             if (reducedMotion) {
-                setStaticPos({ x: e.clientX, y: e.clientY });
+                if (staticPosRafId !== null) {
+                    cancelAnimationFrame(staticPosRafId);
+                }
+                // BOLT OPTIMIZATION: Wrap state updates in requestAnimationFrame for high-frequency events
+                staticPosRafId = requestAnimationFrame(() => {
+                    setStaticPos({ x: e.clientX, y: e.clientY });
+                });
             }
 
             // Target context detection
@@ -244,6 +251,9 @@ const RetroCursor = () => {
             window.removeEventListener('mousedown', handleMouseDown);
             window.removeEventListener('mouseup', handleMouseUp);
             cancelAnimationFrame(animationFrameId);
+            if (staticPosRafId !== null) {
+                cancelAnimationFrame(staticPosRafId);
+            }
         };
     }, [reducedMotion]);
 


### PR DESCRIPTION
💡 What: Wrapped the `setStaticPos` state update in `RetroCursor.tsx` inside a `requestAnimationFrame` and handled the cleanup logic.
🎯 Why: Directly updating React state inside high-frequency native event listeners like `mousemove` causes excessive re-renders, layout thrashing, and can block the main thread.
📊 Impact: Throttles React state updates to the display's refresh rate (e.g., 60Hz), significantly reducing the render workload and preventing potential UI jank without sacrificing visual responsiveness.
🔬 Measurement: Use the Chrome DevTools Performance tab to record a profile while moving the mouse rapidly. Observe the reduction in React render/commit cycles and frame drops.

---
*PR created automatically by Jules for task [2933981763524098166](https://jules.google.com/task/2933981763524098166) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor responsiveness and smoother movement for users with reduced-motion settings.
  * Prevented outdated cursor updates from appearing during rapid movement or component cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->