### PR TITLE
🛡️ Sentinel: [security improvement] Enforce subject field length limits

### DIFF
--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -39,6 +39,11 @@ export async function submitContactForm(formData: { name: string; email: string;
         return { success: false, error: 'Message must be between 10 and 5000 characters.' };
     }
 
+    // SECURITY: Enforce reasonable length limits on optional fields to prevent Application-layer DoS
+    if (subject.length > 200) {
+        return { success: false, error: 'Subject must be less than 200 characters.' };
+    }
+
     const safeName = escapeHTML(name);
     const safeEmail = escapeHTML(email);
     const safeMessage = escapeHTML(message);

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -599,6 +599,7 @@ const Contact = () => {
                                                     </button>
                                                 ))}
                                             </div>
+                                            {/* SECURITY: Explicitly enforce maxLength to align with server-side limits and prevent DoS */}
                                             <input
                                                 id="subject"
                                                 name="subject"
@@ -607,6 +608,7 @@ const Contact = () => {
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
                                                 placeholder="Subject details..."
                                                 type="text"
+                                                maxLength={200}
                                             />
                                         </div>
                                         <div>


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The `subject` field on the contact form lacked an explicit length limit, allowing arbitrarily large strings to be sent to the server.
**🎯 Impact:** Oversized payloads in optional fields like `subject` can lead to Application-Layer DoS or memory exhaustion during parsing or rendering, especially when interpolated into server-side functions like the Resend email integration. 
**🔧 Fix:** 
- Enforced a 200-character max length constraint on the server in `src/app/actions/contact.ts`.
- Added a complementary `maxLength={200}` property on the client `subject` input in `src/components/Contact.tsx`.
- Included `SECURITY` comments explaining the defense-in-depth intent.
**✅ Verification:** 
- Visual verification with Playwright confirms the client-side constraint prevents exceeding 200 characters on the form.
- `pnpm build` verified that types and build step are unharmed.
- `node --test` executed flawlessly.

---
*PR created automatically by Jules for task [9954846960377668599](https://jules.google.com/task/9954846960377668599) started by @SudoAnirudh*