### PR TITLE
⚡ Bolt: [performance improvement] Optimize mousemove in RetroLoader

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2025-02-12 - [Optimize High-Frequency Mousemove state updates]
+**Learning:** Setting React state continuously inside a \`mousemove\` event listener triggers cascading renders and causes significant main thread blocking and layout thrashing, hurting performance.
+**Action:** Always wrap state updates inside \`mousemove\` event handlers in \`requestAnimationFrame\` and cancel the pending frame when a new event arrives or the component unmounts.

--- a/src/components/RetroLoader.tsx
+++ b/src/components/RetroLoader.tsx
@@ -88,12 +88,18 @@ const RetroLoader = () => {
         setShowLoader(true);
         document.body.classList.add('overflow-hidden');
 
+        let rafId: number;
+
         const handleMouseMove = (e: MouseEvent) => {
-            const { innerWidth, innerHeight } = window;
-            // Calculate mouse position relative to center of screen, bounded between -1 and 1
-            const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
-            const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
-            setMousePos({ x, y });
+            if (rafId) cancelAnimationFrame(rafId);
+            rafId = requestAnimationFrame(() => {
+                const { innerWidth, innerHeight } = window;
+                // Calculate mouse position relative to center of screen, bounded between -1 and 1
+                const x = (e.clientX - innerWidth / 2) / (innerWidth / 2);
+                const y = (e.clientY - innerHeight / 2) / (innerHeight / 2);
+                // PERFORMANCE: Wrap state update in requestAnimationFrame to prevent layout thrashing and main thread blocking
+                setMousePos({ x, y });
+            });
         };
 
         window.addEventListener('mousemove', handleMouseMove);
@@ -135,6 +141,7 @@ const RetroLoader = () => {
         }, 4800);
 
         return () => {
+            if (rafId) cancelAnimationFrame(rafId);
             clearTimeout(t1);
             clearTimeout(t2);
             clearTimeout(t3);


### PR DESCRIPTION
💡 What: Wrapped `setMousePos` state update in `requestAnimationFrame` inside the `mousemove` event listener of `RetroLoader.tsx`. The pending frame is cancelled when a new event arrives or the component unmounts.
🎯 Why: Setting React state continuously on high-frequency events like `mousemove` causes cascading re-renders and main thread blocking, which can result in noticeable jank during the startup animation. 
📊 Impact: Reduces layout thrashing and synchronizes React re-renders with the display's native refresh rate, creating a smoother animation.
🔬 Measurement: Verify by starting the application and observing the CPU/FPS profile during the bootloader sequence when the mouse is moved rapidly.

---
*PR created automatically by Jules for task [1889823268924841473](https://jules.google.com/task/1889823268924841473) started by @SudoAnirudh*