### PR TITLE
🎨 Palette: [UX improvement] Add required field indicators to Contact form

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
💡 What: Added explicit visual asterisks to required input fields (`name`, `email`, `message`) in the contact form (`src/components/Contact.tsx`).
🎯 Why: To clearly communicate to users which form fields are required before they attempt to submit, preventing confusion and improving form accessibility.
📸 Before/After: Verified visual layout and styling locally via Playwright screenshots and video in `/home/jules/verification/`.
♿ Accessibility: Uses `<span aria-hidden="true">*</span>` directly inside the corresponding `<label>` element for visual indication without creating screen reader auditory clutter.

---
*PR created automatically by Jules for task [16111148611800391953](https://jules.google.com/task/16111148611800391953) started by @SudoAnirudh*