### PR TITLE
⚡ Bolt: [performance improvement] Throttle RetroMusicPlayer mousemove events

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2026-08-10 - [Throttle High-Frequency Mousemove Events]
+**Learning:** When syncing `mousemove` event coordinates directly to React state (e.g., via `setPosition` or `setMousePos`), processing state updates synchronously on every pixel movement causes significant layout thrashing and main thread blocking.
+**Action:** Always wrap the state update in `requestAnimationFrame` to prevent layout thrashing and ensure `cancelAnimationFrame` is called in the unmount cleanup or when a new frame is scheduled.

--- a/src/components/RetroMusicPlayer.tsx
+++ b/src/components/RetroMusicPlayer.tsx
@@ -58,11 +58,18 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
         };
     };
 
+    // PERFORMANCE: Throttle React state updates from mousemove events using requestAnimationFrame to prevent layout thrashing and main thread blocking.
+    const rafId = useRef<number | null>(null);
     const handleMouseMove = (e: MouseEvent) => {
         if (isDragging && !embedded) {
-            setPosition({
-                x: e.clientX - dragOffset.current.x,
-                y: e.clientY - dragOffset.current.y
+            if (rafId.current !== null) {
+                cancelAnimationFrame(rafId.current);
+            }
+            rafId.current = requestAnimationFrame(() => {
+                setPosition({
+                    x: e.clientX - dragOffset.current.x,
+                    y: e.clientY - dragOffset.current.y
+                });
             });
         }
     };
@@ -82,6 +89,9 @@ const RetroMusicPlayer = ({ embedded = false, onClose }: { embedded?: boolean; o
         return () => {
             window.removeEventListener('mousemove', handleMouseMove);
             window.removeEventListener('mouseup', handleMouseUp);
+            if (rafId.current !== null) {
+                cancelAnimationFrame(rafId.current);
+            }
         };
     }, [isDragging]);
 


### PR DESCRIPTION
💡 What: Wrapped the `mousemove` state updates (`setPosition`) in `RetroMusicPlayer.tsx` within a `requestAnimationFrame` block to throttle execution to screen refresh rate, caching the frame ID to allow clean unmounting and cancellation.

🎯 Why: Dragging elements that tie raw `mousemove` event coordinates directly to synchronous React state updates causes massive layout thrashing, main thread blockages, and input lag due to high-polling-rate mice triggering hundreds of cascading renders per second.

📊 Impact: Reduces layout thrashing and prevents blocking of the main thread during high-frequency drag events on the music player, leading to smoother animations and lower CPU overhead on all devices.

🔬 Measurement: Verified using Next.js build compilation and Playwright automation without UI rendering regressions. Tests successfully passed.

---
*PR created automatically by Jules for task [8579235703694682910](https://jules.google.com/task/8579235703694682910) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved music player dragging responsiveness by smoothing mouse-position updates.
  * Prevented unnecessary updates while dragging for a more stable interaction.
* **Documentation**
  * Added guidance on efficiently handling high-frequency mouse movement updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->