### PR TITLE
🎨 Palette: Add visual indicators to required form fields

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
💡 What: Added explicit visual asterisk indicators (`*`) to the required fields (Name, Email, Message) in the contact form.
🎯 Why: Users need clear, upfront visual cues for which form fields are mandatory to prevent validation errors on submission.
📸 Before/After: Replaced standard labels with labels containing a red asterisk for required fields.
♿ Accessibility: Ensured the asterisk is hidden from screen readers (`aria-hidden="true"`) since the inputs are already marked with `required`, preventing redundant announcements.

---
*PR created automatically by Jules for task [5957532775244277904](https://jules.google.com/task/5957532775244277904) started by @SudoAnirudh*