### PR TITLE
⚡️ Sentinel: [security improvement] Add length limits to optional form fields

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** Missing client-side length validation on contact form inputs.
 **Learning:** Client-side inputs lacked maxLength attributes corresponding to server-side constraints in actions/contact.ts, which could allow rudimentary application-layer DoS via oversized payloads.
 **Prevention:** Always ensure client-side form inputs enforce maxLength attributes explicitly aligned with their server-side validation counterparts.
+## 2026-08-10 - [Security] Add client-side and server-side length validation to optional fields
+**Vulnerability:** Missing input validation (specifically length validation) on the optional `subject` field in the contact form, which could allow rudimentary application-layer DoS via oversized payloads.
+**Learning:** Even optional fields must have strict length limitations on both the client side (`maxLength`) and server side to prevent malicious actors from submitting massive payloads that exhaust server resources or cause database/API errors.
+**Prevention:** Always enforce strict length limits on all user inputs, including optional fields, on both the frontend and backend.

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -39,6 +39,11 @@ export async function submitContactForm(formData: { name: string; email: string;
         return { success: false, error: 'Message must be between 10 and 5000 characters.' };
     }
 
+    // SECURITY: Enforce max length on optional subject field to prevent Denial of Service (DoS) via resource exhaustion
+    if (subject && subject.length > 200) {
+        return { success: false, error: 'Subject must be less than 200 characters.' };
+    }
+
     const safeName = escapeHTML(name);
     const safeEmail = escapeHTML(email);
     const safeMessage = escapeHTML(message);

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -599,6 +599,7 @@ const Contact = () => {
                                                     </button>
                                                 ))}
                                             </div>
+                                            {/* SECURITY: Enforce maxLength on optional subject field to prevent application-layer DoS via oversized payloads */}
                                             <input
                                                 id="subject"
                                                 name="subject"
@@ -607,6 +608,7 @@ const Contact = () => {
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
                                                 placeholder="Subject details..."
                                                 type="text"
+                                                maxLength={200}
                                             />
                                         </div>
                                         <div>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing input length limits on the optional `subject` field.
🎯 Impact: Attackers could submit massive payloads, potentially causing resource exhaustion or Denial of Service (DoS) in the application layer.
🔧 Fix: Added client-side `maxLength={200}` to the input field and explicitly enforced this limit server-side, alongside safety null checks to prevent TypeScript build failures.
✅ Verification: Ran `pnpm lint`, `pnpm build`, and unit tests. Visually verified the changes to `src/app/actions/contact.ts` and `src/components/Contact.tsx`.

---
*PR created automatically by Jules for task [5732298886239024947](https://jules.google.com/task/5732298886239024947) started by @SudoAnirudh*