### PR TITLE
⚡️ Sentinel: [security improvement] Enforce length validation on optional subject field

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Missing client-side length validation on contact form inputs.
 **Learning:** Client-side inputs lacked maxLength attributes corresponding to server-side constraints in actions/contact.ts, which could allow rudimentary application-layer DoS via oversized payloads.
 **Prevention:** Always ensure client-side form inputs enforce maxLength attributes explicitly aligned with their server-side validation counterparts.
+
+## 2026-08-11 - [Missing Validation on Optional Field]
+**Vulnerability:** The optional 'subject' field in the contact form lacked a length restriction on both the client (missing maxLength) and server (missing length validation), allowing potential application-layer DoS via excessively large payloads.
+**Learning:** Optional fields are just as susceptible to injection and payload-size attacks as required fields. Developers often overlook length limits on fields that aren't strictly required for processing.
+**Prevention:** Always enforce explicit length constraints on all input fields—both required and optional—aligning client-side `maxLength` attributes with server-side validation checks.

--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -39,6 +39,11 @@ export async function submitContactForm(formData: { name: string; email: string;
         return { success: false, error: 'Message must be between 10 and 5000 characters.' };
     }
 
+    // SECURITY: Enforce length limit on optional subject field to prevent DoS via oversized payloads
+    if (subject && subject.length > 200) {
+        return { success: false, error: 'Subject must be less than 200 characters.' };
+    }
+
     const safeName = escapeHTML(name);
     const safeEmail = escapeHTML(email);
     const safeMessage = escapeHTML(message);

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -599,6 +599,7 @@ const Contact = () => {
                                                     </button>
                                                 ))}
                                             </div>
+                                            {/* SECURITY: Enforce maxLength on optional subject input to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                             <input
                                                 id="subject"
                                                 name="subject"
@@ -607,6 +608,7 @@ const Contact = () => {
                                                 className="w-full bg-zinc-50 border-2 border-black/30 rounded-lg p-3 font-body focus:outline-none focus:border-black focus:bg-white transition-colors text-zinc-900 placeholder-zinc-400 text-sm sm:text-base"
                                                 placeholder="Subject details..."
                                                 type="text"
+                                                maxLength={200}
                                             />
                                         </div>
                                         <div>


### PR DESCRIPTION
## 🚨 Severity
MEDIUM

## 💡 Vulnerability
The optional `subject` field in the contact form lacked a length restriction on both the client (missing `maxLength`) and server (missing length validation). This allowed potential application-layer DoS via excessively large payloads sent to the backend and external services (Resend).

## 🎯 Impact
Malicious users could send an unbounded amount of text in the `subject` field, potentially causing resource exhaustion, memory issues, or crashing downstream integrations that process the form payload.

## 🔧 Fix
- Added a `maxLength={200}` attribute to the client-side subject `<input>` field in `src/components/Contact.tsx`.
- Added server-side length validation in `src/app/actions/contact.ts` to reject submissions with a subject longer than 200 characters.
- Logged this learning in `.jules/sentinel.md` regarding the necessity of validating optional fields.

## ✅ Verification
- Simulated large inputs locally and confirmed the server correctly rejects them.
- `pnpm build` completes successfully.
- Code changes were reviewed and adhere to the security boundaries.

---
*PR created automatically by Jules for task [6470488025600276032](https://jules.google.com/task/6470488025600276032) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a 200-character limit to the optional contact-form subject field.
  - Added server-side validation to reject subjects exceeding the limit.
  - Improved protection against excessively long contact-form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->