### PR TITLE
⚡ Bolt: Throttle mousemove state updates with requestAnimationFrame

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,7 @@
 ## 2026-07-30 - [Throttled Scroll Listeners]
 **Learning:** High-frequency event listeners like `scroll` or `resize` that trigger React state updates (e.g., in `Navbar.tsx`) can cause significant main thread blocking and jank if not properly managed.
 **Action:** Always throttle these updates using `requestAnimationFrame` to synchronize with screen refreshes, and use `{ passive: true }` on the event listener to avoid blocking the main thread.
+
+## 2024-10-24 - Wrap React state updates in requestAnimationFrame for high-frequency events
+**Learning:** Updating React state directly inside high-frequency event listeners like `mousemove` causes layout thrashing and main thread blocking, as it triggers rapid unbatched re-renders.
+**Action:** Always wrap state setters inside `requestAnimationFrame` when syncing coordinates or other rapidly changing event data to React state, and ensure the frame ID is captured and canceled in the unmount cleanup.

--- a/src/components/RetroCursor.tsx
+++ b/src/components/RetroCursor.tsx
@@ -89,13 +89,18 @@ const RetroCursor = () => {
         }));
 
         let lastTarget: EventTarget | null = null;
+        let staticPosFrameId: number;
 
         const updateMousePos = (e: MouseEvent) => {
             mousePos.current = { x: e.clientX, y: e.clientY };
             lastMoveTime.current = Date.now();
 
             if (reducedMotion) {
-                setStaticPos({ x: e.clientX, y: e.clientY });
+                // PERFORMANCE: Wrap high-frequency React state update in rAF to prevent layout thrashing
+                if (staticPosFrameId) cancelAnimationFrame(staticPosFrameId);
+                staticPosFrameId = requestAnimationFrame(() => {
+                    setStaticPos({ x: e.clientX, y: e.clientY });
+                });
             }
 
             // Target context detection
@@ -244,6 +249,7 @@ const RetroCursor = () => {
             window.removeEventListener('mousedown', handleMouseDown);
             window.removeEventListener('mouseup', handleMouseUp);
             cancelAnimationFrame(animationFrameId);
+            if (staticPosFrameId) cancelAnimationFrame(staticPosFrameId);
         };
     }, [reducedMotion]);
 


### PR DESCRIPTION
💡 **What**: Wrapped the high-frequency React state update (`setStaticPos`) inside the `mousemove` event handler with a `requestAnimationFrame` call in `RetroCursor.tsx`. The animation frame is properly tracked and canceled during unmount.
🎯 **Why**: When `reducedMotion` is enabled, the `mousemove` handler updates the React state `staticPos` directly. High polling-rate mice trigger this event hundreds of times per second, causing severe layout thrashing and main-thread blocking due to rapid, unbatched React re-renders. Synchronizing state updates with the browser's paint cycle via `requestAnimationFrame` significantly reduces CPU overhead.
📊 **Impact**: Prevents cascading React re-renders, capping the state updates to the monitor's refresh rate (e.g., 60-144 FPS) instead of the mouse's polling rate (up to 1000+ Hz).
🔬 **Measurement**: In Chrome DevTools Performance tab, the "Main" thread activity during continuous mouse movement should show reduced scripting time and fewer layout/paint recalculations when reduced motion is enabled.

---
*PR created automatically by Jules for task [15715487907194327485](https://jules.google.com/task/15715487907194327485) started by @SudoAnirudh*