### PR TITLE
🎨 Palette: Add explicit visual indicators to required form fields

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -548,7 +548,7 @@ const Contact = () => {
                                     {/* SECURITY: Enforce maxLength on form inputs to prevent application-layer DoS via oversized payloads, aligning with server-side validation. */}
                                     <form className="space-y-5 sm:space-y-6" onSubmit={handleSubmit}>
                                         <div>
-                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name</label>
+                                            <label htmlFor="name" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Name<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="name"
                                                 ref={nameInputRef}
@@ -563,7 +563,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email</label>
+                                            <label htmlFor="email" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Email<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <input
                                                 id="email"
                                                 name="email"
@@ -610,7 +610,7 @@ const Contact = () => {
                                             />
                                         </div>
                                         <div>
-                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message</label>
+                                            <label htmlFor="message" className="block font-pixel text-xs uppercase tracking-wider text-zinc-600 mb-1">Your Message<span className="text-red-500 ml-1" aria-hidden="true">*</span></label>
                                             <textarea
                                                 id="message"
                                                 name="message"


### PR DESCRIPTION
## 💡 What
Added explicit visual indicators (red asterisks) to the "Your Name", "Your Email", and "Your Message" form fields in the `Contact.tsx` component. The asterisks are implemented using `<span className="text-red-500 ml-1" aria-hidden="true">*</span>` directly inside the corresponding `<label>` elements.

## 🎯 Why
This micro-UX improvement clearly identifies mandatory fields before the user attempts to submit the form, reducing cognitive load and preventing potential validation errors. It follows established UI conventions for web forms.

## 📸 Before/After
(See attached automated screenshot demonstrating the form with the new red asterisks).

## ♿ Accessibility
The visual asterisks explicitly use `aria-hidden="true"`. This is crucial because the input fields themselves already enforce the `required` constraint, which screen readers will announce. Hiding the visual asterisk from assistive technology prevents redundant and potentially confusing announcements (e.g., "star Your Name") while still providing the necessary visual cue to sighted users.

---
*PR created automatically by Jules for task [1749126359110594233](https://jules.google.com/task/1749126359110594233) started by @SudoAnirudh*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added required-field indicators to the name, email, and message fields in the contact form.
  * Existing form behavior and validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->